### PR TITLE
Update Dockerfile for cypress pipeline run on harvester-ui-test repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,14 @@ RUN apt-get install -y git
 ADD https://dl.min.io/client/mc/release/linux-amd64/mc /usr/local/bin/mc
 RUN chmod +x /usr/local/bin/mc
 
-RUN git clone https://github.com/harvester/tests.git
+RUN git clone https://github.com/harvester/harvester-ui-tests.git
 
-WORKDIR /tests/cypress
+WORKDIR /harvester-ui-tests
 
-COPY . /tests/cypress
+COPY . /harvester-ui-tests
 
 RUN npm install
 
-ENV PATH /tests/cypress/node_modules/.bin:$PATH
+ENV PATH /harvester-ui-tests/node_modules/.bin:$PATH
 
 CMD ["./scripts/e2e"]

--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ npx cypress run --reporter mochawesome --spec "./testcases/dashboard/*.spec.ts"
 1.Generate merged report from json files
 
 ```
-$ npx mochawesome-merge cypress/results/*.json > merge-report.json
+$ npx mochawesome-merge results/*.json > merge-report.json
 
 $ npx mochawesome-merge ./*.json > merge-report.json
 
 # Generate merged json report
-../tests/cypress/merge-report.json
+  /results/merge-report.json
 ```
 
 2. Generate the mochaawesome report in html format
@@ -70,7 +70,7 @@ $ npx mochawesome-report-generator merge-report.json
 
 ```
 
-3. Then we can find the generated HTML report under `/tests/cypress/mochawesome-report/merge-report.html` 
+3. Then we can find the generated HTML report under `/results/mochawesome-report/merge-report.html` 
 
 
 ---
@@ -102,11 +102,11 @@ export function loginTest() {}
 ### Creating Test Skeletons for New Features or Tickets
 
 Frontend Tests
-Further info placed in `cypress/README.md`.
+Further info placed in `./README.md`.
 
-There is a test skeleton spec to use as a template in `tests/cypress/skel/`.
+There is a test skeleton spec to use as a template in `./skel/`.
 
-- If you are adding a test to an existing suite like `tests/integration/login.spec.ts`, you can use the template JSDoc and function call, then add the test steps.
+- If you are adding a test to an existing suite like `./login.spec.ts`, you can use the template JSDoc and function call, then add the test steps.
 - If you are creating a new logical group of tests, copy the `skel.spec.ts` file into `integration` or a subdirectory where it fits better, and rename it appropriately.
 - Add the `@notImplemented` tag to the test case if it hasn't been implemented yet. This will have it shown with that tag on the static site.
 
@@ -256,7 +256,7 @@ metadata:
 The Docker image automatically runs Cypress tests and uploads the results to the MinIO server.
 
 - **Default bucket name**: `cypress-test-report`
-- **Default directory path**: `cypress/results/`
+- **Default directory path**: `./results/`
 
 ### Access Test Results
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,7 @@ npx cypress run --reporter mochawesome --spec "./testcases/dashboard/*.spec.ts"
 1.Generate merged report from json files
 
 ```
-$ npx mochawesome-merge results/*.json > merge-report.json
-
-$ npx mochawesome-merge ./*.json > merge-report.json
+$ npx mochawesome-merge results/*.json > results/merge-report.json
 
 # Generate merged json report
   /results/merge-report.json
@@ -66,11 +64,11 @@ $ npx mochawesome-merge ./*.json > merge-report.json
 
 2. Generate the mochaawesome report in html format
 ```
-$ npx mochawesome-report-generator merge-report.json
+$ npx mochawesome-report-generator results/merge-report.json
 
 ```
 
-3. Then we can find the generated HTML report under `/results/mochawesome-report/merge-report.html` 
+3. Then we can find the generated HTML report under `/mochawesome-report/merge-report.html` 
 
 
 ---

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -12,8 +12,8 @@ export default defineConfig({
   fixturesFolder: './fixtures',
   numTestsKeptInMemory: 1,
   chromeWebSecurity: false,
-  screenshotsFolder: 'cypress/results/mochawesome-report/assets',
-  downloadsFolder: 'cypress/downloads',
+  screenshotsFolder: 'results/mochawesome-report/assets',
+  downloadsFolder: 'downloads',
   env: {
     NODE_ENV: 'production',
     username: 'admin',
@@ -55,7 +55,7 @@ export default defineConfig({
   },
   reporter: 'mochawesome',
   reporterOptions: {
-    reportDir: 'cypress/results',
+    reportDir: 'results',
     overwrite: false,
     html: false,
     json: true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvester",
   "description": "Harvester e2e test",
-  "repository": "https://github.com/harvester/tests",
+  "repository": "https://github.com/harvester/harvester-ui-tests",
   "license": "Apache-2.0",
   "author": "SUSE",
   "private": true,
@@ -35,12 +35,12 @@
     "node": "^12.22 || ^14.13 || >=16"
   },
   "scripts": {
-    "delete:reports": "rm cypress/results/* || true",
+    "delete:reports": "rm results/* || true",
     "prereport": "npm run delete:reports",
     "report": "node scripts/run.js",
     "open": "./node_modules/.bin/cypress open",
     "e2e": "./node_modules/.bin/cypress run --browser electron --reporter mochawesome",
-    "report:merge": "rm -rf cypress/results/merge && mkdir -p cypress/results/merge && ./node_modules/.bin/mochawesome-merge 'cypress/results/*.json' > cypress/results/merge/mochawesome.json && ./node_modules/.bin/marge cypress/results/merge/mochawesome.json -o cypress/results/mochawesome-report",
-    "report:html": "yarn report:merge && open cypress/results/mochawesome-report/mochawesome.html"
+    "report:merge": "rm -rf results/merge && mkdir -p results/merge && ./node_modules/.bin/mochawesome-merge 'results/*.json' > results/merge/mochawesome.json && ./node_modules/.bin/marge results/merge/mochawesome.json -o results/mochawesome-report",
+    "report:html": "yarn report:merge && open results/mochawesome-report/mochawesome.html"
   }
 }

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -22,16 +22,16 @@ else
   REPORT_NAME="${timestamp}-${commit_id}"
 fi
 
-report_dir="cypress/results/${REPORT_NAME}"
+report_dir="results/${REPORT_NAME}"
 
 mkdir -p ${report_dir}
 
-cp -rf cypress/results/mochawesome-report/assets/ ${report_dir}
+cp -rf results/mochawesome-report/assets/ ${report_dir}
 
-./node_modules/.bin/mochawesome-merge 'cypress/results/*.json' > ${report_dir}/merge.json 
+./node_modules/.bin/mochawesome-merge 'results/*.json' > ${report_dir}/merge.json 
 ./node_modules/.bin/marge ${report_dir}/merge.json -o ${report_dir} -f index.html
 
-minio_dir="cypress-test-report/cypress/results/"
+minio_dir="cypress-test-report/results/"
 minio_name="minio"
 
 mc alias set ${minio_name} $MINIO_ENDPOINT $MINIO_ACCESS_KEY $MINIO_SECRET_KEY --insecure

--- a/scripts/list-reporters
+++ b/scripts/list-reporters
@@ -1,5 +1,5 @@
 #!/bin/bash
-minio_dir="cypress-test-report/cypress/results/"
+minio_dir="cypress-test-report/results/"
 minio_name="minio"
 
 files=$(mc ls ${minio_name}/${minio_dir} --insecure)

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -15,6 +15,6 @@ cypress.run().then(
 
 function generateReport(options) {
   return merge({
-    files: ['./cypress/results/*.json']
+    files: ['./results/*.json']
   }).then(report => marge.create(report, options))
 }


### PR DESCRIPTION

### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue: 
 - https://github.com/harvester/tests/issues/1818
   

### What this PR does / why we need it:
* We have create the new [harvester-ui-tests](https://github.com/harvester/harvester-ui-tests/) repository and move all existing cypress/tests code to it.

* After we adjust the existing `harvester-cypress-tests` and `harvester-cypress-run-tests` pipeline in the harvester-baremetal-ansible repository.

* In order for the cypress jenkins pipeline to get the correct default folder path in the `harvester-ui-tests` repository

* We need to adjust the build and copy path in the cypress/Dockerfile  

### Fix and Improvements

1. Update the `WORKDIR` and `COPY` command path to fit the new `harvester-ui-tests` structure

  ```
  ...
  
  WORKDIR /harvester-ui-tests
  
  COPY . /harvester-ui-tests
  
  ...
  ```


### Test Result

Verified can well execute `cypress_test` and `cypress_run_test` pipeline well on the staging Jenkins 
And can also correctly generate and display HTML report on the job page 

* `cypress-test` pipeline result
  - http://10.115.1.12/job/harvester-cypress-test/79/console

    ![image](https://github.com/user-attachments/assets/4b74cc2d-66e5-429d-8df9-9e5bcce126af)

  - http://10.115.1.12/job/harvester-cypress-test/79/HTML_20Report/

    ![image](https://github.com/user-attachments/assets/a62d0252-4ca1-48cb-bfe7-c5d899e3b943)


* `cypress-run-test` pipeline result 
  - http://10.115.1.12/job/harvester-cypress-run-test/5/console

    ![image](https://github.com/user-attachments/assets/11dbd079-1f9c-45f6-b2a0-97d572f0b14b)

  - http://10.115.1.12/job/harvester-cypress-run-test/5/HTML_20Report/

   
    ![image](https://github.com/user-attachments/assets/e0496737-cc3c-4ab7-9334-7426ca01c260)

### Additional context
Need to test with PR https://github.com/harvester/harvester-baremetal-ansible/pull/95/
