### PR TITLE
Fix: two failed cypress tests on Harvester v1.4.2-rc1

### DIFF
--- a/pageobjects/virtualmachine.po.ts
+++ b/pageobjects/virtualmachine.po.ts
@@ -101,7 +101,7 @@ export class VmsPage extends CruResourcePo {
   selectSchedulingType({ type = 'any' }: { type: string }) {
     const map: any = {
       any: 'Run virtual machine on any available node',
-      specific: 'Run virtual machine on specific node - (Live migration is not supported))',
+      specific: 'Run virtual machine on specific node - (Live migration is not supported)',
       rules: 'Run virtual machine on node(s) matching scheduling rules'
     }
 

--- a/testcases/image/images.spec.ts
+++ b/testcases/image/images.spec.ts
@@ -321,7 +321,7 @@ describe('Create a ISO image via upload', () => {
 
         image.goToCreate();
         image.setNameNsDescription(IMAGE_NAME, namespace);
-        image.setBasics({ path: 'cypress/fixtures/cirros-0.5.2-aarch64-disk.img' });
+        image.setBasics({ path: 'fixtures/cirros-0.5.2-aarch64-disk.img' });
 
         cy.wrap(image.save({ upload: true })).then((realName) => {
             image.checkState({ name: IMAGE_NAME });


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
* Issue https://github.com/harvester/tests/issues/1888

#### What this PR does / why we need it:

* According to the latest cypress-test result on the staging Jenkins for Harvester `v1.4.2-rc1`
  - http://10.115.1.12/job/harvester-cypress-test/84/console
 
* After checking the test report:
  - http://10.115.1.12/job/harvester-cypress-test/84/HTML_20Report/

* There are two failed tests need to update test script 

   - Create a ISO image via upload
   - Schedule VM on the Node which is Enable Maintenance Mode

#### Test Result - fixed the following test cases:

* PASS the `Schedule VM on the Node which is Enable Maintenance Mode` 
  - http://10.115.1.12/job/harvester-cypress-run-test/18/HTML_20Report/
  ![image](https://github.com/user-attachments/assets/7775f542-fde4-48d7-ac83-1c5b8797b31c)

* PASS the `Create a ISO image via upload` 
  - http://10.115.1.12/job/harvester-cypress-run-test/20/HTML_20Report/
  ![image](https://github.com/user-attachments/assets/703523b5-bd3c-4af6-ac70-e98d2787e67e)

