### PR TITLE
Fix: Restore volume snapshot test case failed

### DIFF
--- a/pageobjects/volume.po.ts
+++ b/pageobjects/volume.po.ts
@@ -41,6 +41,11 @@ export class VolumePage extends CruResourcePo {
     return new LabeledSelectPo(".labeled-select", `:contains("Image"):last`);
   }
 
+  checkVolumeNameExist(volumeName: string,  namespace: string = 'default') {
+    this.goToList();
+    this.censorInColumn(volumeName, 3, namespace, 4, volumeName, 3);
+  }
+
   checkState(name: string, state: string = 'Ready', namespace: string = 'default') {
     this.goToList();
     this.censorInColumn(name, 3, namespace, 4, state, 2);

--- a/testcases/backupAndSnapshot/volumeSnapshot.spec.ts
+++ b/testcases/backupAndSnapshot/volumeSnapshot.spec.ts
@@ -43,7 +43,7 @@ describe('Validation volume snapshot', () => {
     createVolumeSnapshotSuccess = true
   })
 
-  it('Restore New volume from volume snapshot', () => {
+  it('Restore new volume from volume snapshot', () => {
     onlyOn(createVolumeSnapshotSuccess);
     
     const newName = 'create-new-from-snapshot';
@@ -53,8 +53,8 @@ describe('Validation volume snapshot', () => {
     volumeSnapshots.goToList();
     volumeSnapshots.restoreNew(volumeSnapshotName, newName);
 
-    // check volume
-    volumes.checkState(newName);
+    // check restore volume exists
+    volumes.checkVolumeNameExist(newName);
 
     // delete volume
     volumes.deleteFromStore(`default/${newName}`);


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
* Issue https://github.com/harvester/tests/issues/1888


Fix below error

<img width="1161" alt="image" src="https://github.com/user-attachments/assets/e9387ca0-79a5-4285-9aa1-758b698af8f2" />

Root cause  : after restore volume snapshot -> volume, the volume status changes from `Not Ready` -> `Degraded` -> `Ready`.  The code directly checks status becomes ready. 

I suggest using a more loose approach by simply verifying the existence of the created volume to avoid flaky test.

**After fix**

<img width="1496" alt="Screenshot 2025-02-24 at 11 10 52 AM" src="https://github.com/user-attachments/assets/42ddcff3-a3bb-4660-8c12-1022f85de320" />

