### PR TITLE
change support bundle download timeout to 10 mins

### DIFF
--- a/constants/constants.ts
+++ b/constants/constants.ts
@@ -1,5 +1,5 @@
 export class Constants {
-    public timeout = { timeout: 10000, maxTimeout: 60000, uploadTimeout: 600000, downloadTimeout: 240000, provisionTimeout: 1500000 };
+    public timeout = { timeout: 10000, maxTimeout: 60000, uploadTimeout: 600000, downloadTimeout: 600000, provisionTimeout: 1500000 };
     public username = Cypress.env("username");
     public password = Cypress.env("password");
     public mockPassword = Cypress.env("mockPassword");


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
* Issue https://github.com/harvester/tests/issues/1888


<img width="949" alt="image" src="https://github.com/user-attachments/assets/227fa649-c2d7-4002-b481-32de402324a4" />

#### What this PR does / why we need it:

Extend download support bundle timeout from 4 mins -> 10 mins to make test more steady

#### Test Result - fixed the following test cases:
N/A


