### PR TITLE
Check volume size instead of volume status

### DIFF
--- a/testcases/volume/volumes.spec.ts
+++ b/testcases/volume/volumes.spec.ts
@@ -283,8 +283,8 @@ describe("Edit volume increase size via form", () => {
       volumes.setBasics({ size: '15' });
       volumes.update(`${namespace}/${volumeName}`);
 
-      // check VOLUME state
-      volumes.censorInColumn(volumeName, 3, namespace, 4, 'In-use', 2);
+      // check VOLUME size change to 15 Gi
+      volumes.censorInColumn(volumeName, 3, namespace, 4, '15 Gi', 5);
 
       // delete VM
       vms.delete(namespace, VM_NAME);


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
* Issue : https://github.com/harvester/tests/issues/1888

#### What this PR does / why we need it:
The status of resizing a volume is Resizing -> Degraded -> In use.

For `Edit volume increase size via form` test case, we can just check the volume size is changed 
 
<img width="962" alt="image" src="https://github.com/user-attachments/assets/bc377dc0-8ab5-4a31-964c-1311a4959c05" />

#### Test Result - fixed the following test cases:

<img width="1492" alt="Screenshot 2025-02-26 at 10 51 33 PM" src="https://github.com/user-attachments/assets/0781cf26-3f4f-4ed7-83cf-36b4663bfab1" />
