### PR TITLE
Fix: failed network cypress tests on v1.5.0-rc1

### DIFF
--- a/pageobjects/network.po.ts
+++ b/pageobjects/network.po.ts
@@ -41,7 +41,7 @@ export default class NetworkPage extends CruResourcePo {
   }
 
   vlan() {
-    return new LabeledInputPo('.labeled-input', `:contains("VLAN ID")`)
+    return new LabeledInputPo('.labeled-input', `:contains("Vlan ID")`)
   }
 
   clusterNetwork() {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
* Issue : https://github.com/harvester/tests/issues/1928

#### What this PR does / why we need it:

* According to the latest cypress-test result on the staging Jenkins for Harvester `v1.5.0-rc1`
  - http://10.115.1.12/job/harvester-cypress-test/88/
 
* After checking the test report:
  - http://10.115.1.12/job/harvester-cypress-test/88/HTML_20Report/

* There are five failed tests need to update test script 


1. Check create/delete network
2. Check network with DHCP
3. Check network with Manual Mode
4. Create Vlan1
5. Create Vlan2

#### Test Result - fixed the following test cases:

  ![image](https://github.com/user-attachments/assets/77c5ea0d-3918-431a-8628-63a6a9d1ae67)



