### PR TITLE
fix unable to stop VM in some test cases

### DIFF
--- a/utils/components/cru-resource.po.ts
+++ b/utils/components/cru-resource.po.ts
@@ -202,7 +202,14 @@ export default class CruResourcePo extends PagePo {
     const record = cy.contains(name)
     expect(record.should('be.visible'))
     record.parentsUntil('tbody', 'tr').find(this.actionMenuIcon).click()
-    return cy.get(this.actionMenu).contains(action).click()
+    // VM stop/pause actions has to click apply in one more confirmation modal
+    if(action?.toLowerCase() === 'stop' || action?.toLowerCase() === 'pause') {
+      cy.get(this.actionMenu).contains(action).click()
+      return cy.get('#modals button[data-testid="action-button-async-button"]').click()
+    }else{
+      return cy.get(this.actionMenu).contains(action).click()
+    }
+   
   }
 
   public checkEdit(name: string, namespace?: string, value?: any, action: string = 'Edit Config') {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.

-->
* Issue : https://github.com/harvester/tests/issues/1928

Fix test cases
- Restore Existing VM from vm snapshot
- Restore Existing VM from vm backup
- Edit volume increase size via form
- Stop VM Negative



#### What this PR does / why we need it:
There is one more modal needs to confirm for VM stop / pause action.

<img width="1486" alt="Screenshot 2025-03-14 at 11 02 47 AM" src="https://github.com/user-attachments/assets/b0a0ca2a-439e-4283-a770-c5e463919660" />

#### Test Result - fixed the following test cases:
<img width="1496" alt="Screenshot 2025-03-14 at 11 14 38 AM" src="https://github.com/user-attachments/assets/e1bf0987-e30b-436e-9fae-299b9b6e29ca" />
<img width="1446" alt="image" src="https://github.com/user-attachments/assets/10c37347-cb71-4bdf-b7a9-69241bfcf796" />
<img width="1491" alt="image" src="https://github.com/user-attachments/assets/1a5863a5-0612-4970-baf1-dd2c16e13de5" />

