### PR TITLE
fix unable to check Booting in EFI mode checkbox

### DIFF
--- a/utils/components/checkbox.po.ts
+++ b/utils/components/checkbox.po.ts
@@ -7,8 +7,8 @@ export default class CheckboxPo extends ComponentPo {
     }
 
     this.self().find('[role="checkbox"]').invoke('attr', 'aria-checked').then(isChecked => {
-      if ((newValue && !Boolean(isChecked)) || (!newValue && Boolean(isChecked))) {
-        this.self().click()
+      if ((newValue && isChecked === 'false') || (!newValue && isChecked === 'true')) {
+        this.self().click({ force: true })
       }
     })
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
* Issue : https://github.com/harvester/tests/issues/1928

Failed reason : checkbox is not check as expected. Fix 
- Template with EFI
- Create a new VM with Booting in EFI mode checked

#### What this PR does / why we need it:
This issue is where JS weak type magic is.

```
isChecked = false (string)

Boolean(isChecked) => true
```

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/Boolean#creating_boolean_objects_with_an_initial_value_of_true

#### Test Result - fixed the following test cases:

<img width="1496" alt="Screenshot 2025-03-14 at 12 22 40 PM" src="https://github.com/user-attachments/assets/c4eadfa5-e199-4428-98ac-6dda6a8d2bea" />
<img width="1482" alt="Screenshot 2025-03-14 at 12 22 58 PM" src="https://github.com/user-attachments/assets/08c1b2b7-43b9-4f86-abe6-384941028f24" />
