### PR TITLE
Reload the page before plugging a new volume

### DIFF
--- a/pageobjects/virtualmachine.po.ts
+++ b/pageobjects/virtualmachine.po.ts
@@ -388,6 +388,8 @@ export class VmsPage extends CruResourcePo {
     this.goToList();
     cy.wait(2000);
     cy.wrap(volumeNames).each((V: string) => {
+      // reload the page before plugging a new volume
+      cy.reload()
       this.clickAction(vmName, 'Add Volume').then((_) => {
         cy.get('.modal-container .card-container').within(() => {
           this.plugVolumeCustomName().input(V);


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
* Issue :  https://github.com/harvester/tests/issues/1928

#### What this PR does / why we need it:
Looks like consecutively hotplug two volumes, backend will complain below error.

<img width="1079" alt="Screenshot 2025-04-14 at 4 55 36 PM" src="https://github.com/user-attachments/assets/f0aacea9-1b46-4a5c-949e-34a3150f8d48" />


#### Test Result - fixed the following test cases:
<img width="1496" alt="Screenshot 2025-04-14 at 5 09 40 PM" src="https://github.com/user-attachments/assets/fac32f72-433d-4264-93eb-03f53e1c3d21" />

