### PR TITLE
Fix Rancher first time login on v2.10.4 and v2.11.0

### DIFF
--- a/pageobjects/rancher.po.ts
+++ b/pageobjects/rancher.po.ts
@@ -27,9 +27,9 @@ interface ValueInterface {
 
 export class rancherPage {
 
-    private login_page_usernameInput = '#username';
-    private login_page_passwordInput = '#password > .labeled-input > input';
-    private login_page_loginButton = '#submit > span';
+    private login_page_usernameInput = '[data-testid="local-login-username"]';
+    private login_page_passwordInput = '[data-testid="local-login-password"]';
+    private login_page_loginButton = '[data-testid="login-submit"]';
     private main_page_title = '.title';
     private dashboardURL = 'dashboard/home';
 
@@ -109,11 +109,15 @@ export class rancherPage {
     */
     public static isFirstTimeLogin(): Promise<boolean> {
         return new Promise((resolve, reject) => {
-            cy.intercept('GET', '/v1/management.cattle.io.setting?exclude=metadata.managedFields').as('getFirstLogin')
+            // Use a regex to match both /setting? and /settings? URLs
+            const settingsUrlRegex = /\/v1\/management\.cattle\.io\.settings?\?exclude=metadata\.managedFields/;
+
+            cy.intercept('GET', settingsUrlRegex).as('getFirstLogin')
                 .visit("/")
                 .wait('@getFirstLogin').then(login => {
                     const data: any[] = login.response?.body.data;
                     const firstLogin = data.find(v => v?.id === "first-login");
+                    console.log(firstLogin);
                     resolve(firstLogin.value === 'true');
                 })
                 .end();


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
* Issue : https://github.com/harvester/tests/issues/2029

#### What this PR does / why we need it:

We need to fix the cypress execution failure of the `Rancher First Login` after Rancher v2.10 above
  - v2.10.4
  - v2.11.0
  - v2.8.5


#### Test Result - fixed the following test cases:

* Test result on Rancher v2.11.0 


  https://github.com/user-attachments/assets/4bdd4149-8e0d-4a2b-9391-38a981314458


* Test result on Rancher v2.10.4 


  https://github.com/user-attachments/assets/6cd8e8f5-c22f-4b30-8deb-b83b0d1b3fda



* Test result on Rancher v2.8.5 

  https://github.com/user-attachments/assets/e658804e-415f-4907-be72-0014a9ef0cd3




