### PR TITLE
(release-v1.4) Add new tests to add repo and install Harverster UI extension

### DIFF
--- a/constants/constants.ts
+++ b/constants/constants.ts
@@ -8,9 +8,9 @@ export class Constants {
     public rancher_password = Cypress.env("rancherPassword");
     public rancher_vm_user = Cypress.env("rancher_vm_user");
     public rancher_vm_password = Cypress.env("rancher_vm_password");
-    public rancher_ui_extension_repo_url = Cypress.env("ui_extension_repo_url");
-    public rancher_ui_extension_branch = Cypress.env("ui_extension_branch");
-    public rancher_ui_extension_version = Cypress.env("ui_extension_version");
+    public harvester_ui_extension_repo_url = Cypress.env("harvester_ui_extension_repo_url");
+    public harvester_ui_extension_branch = Cypress.env("harvester_ui_extension_branch");
+    public harvester_ui_extension_version = Cypress.env("harvester_ui_extension_version");
     public vagrant_pxe_path = Cypress.env("vagrant_pxe_path");
     public setupUrl = '/auth/setup/';
     public loginUrl = '/auth/login/';

--- a/constants/constants.ts
+++ b/constants/constants.ts
@@ -8,6 +8,9 @@ export class Constants {
     public rancher_password = Cypress.env("rancherPassword");
     public rancher_vm_user = Cypress.env("rancher_vm_user");
     public rancher_vm_password = Cypress.env("rancher_vm_password");
+    public rancher_ui_extension_repo_url = Cypress.env("ui_extension_repo_url");
+    public rancher_ui_extension_branch = Cypress.env("ui_extension_branch");
+    public rancher_ui_extension_version = Cypress.env("ui_extension_version");
     public vagrant_pxe_path = Cypress.env("vagrant_pxe_path");
     public setupUrl = '/auth/setup/';
     public loginUrl = '/auth/login/';
@@ -29,6 +32,8 @@ export class Constants {
     public rancher_clusterManagmentPage = '/c/local/manager/provisioning.cattle.io.cluster';
     public rancher_cloudCredentialPage = '/c/local/manager/cloudCredential';
     public rancher_nodeTamplatePage = '/c/local/manager/pages/node-templates';
+    public rancher_apps_repositories = '/c/local/apps/catalog.cattle.io.clusterrepo';
+    public rancher_available_extensions = '/c/_/uiplugins#available';
 }
 
 export const PageUrl = {

--- a/cypress.env.json.example
+++ b/cypress.env.json.example
@@ -8,6 +8,9 @@
   "rancherUser": "admin",
   "rancherPassword": "admin",
   "rancherBootstrapPassword": "admin",
+  "harvester_ui_extension_repo_url": "https://github.com/harvester/harvester-ui-extension",
+  "harvester_ui_extension_branch": "v1.0-head",
+  "harvester_ui_extension_version": "1.0.6-rc1",
   "host": [
     {
       "name": "",

--- a/pageobjects/rancher.po.ts
+++ b/pageobjects/rancher.po.ts
@@ -135,6 +135,21 @@ export class rancherPage {
         });
     }
 
+    public getServerVersion(): Promise<string> {
+        return new Promise((resolve, reject) => {
+            const serverVersionUrl = '/rancherversion';
+
+            cy.intercept('GET', serverVersionUrl).as('getServerVersion')
+                .visit("/")
+                .wait('@getServerVersion').then(res => {
+                    const responsebody = res.response?.body;
+                    resolve(responsebody as string);
+                })
+                .end();
+        });
+
+    }
+
     /**
      * First time login using ssh 
      */

--- a/pageobjects/rancher.po.ts
+++ b/pageobjects/rancher.po.ts
@@ -50,6 +50,18 @@ export class rancherPage {
     private virtual_page_clusterName = ':nth-child(1) > .labeled-input > input';
     private virtual_page_createCluster = '.cru-resource-footer > div > .role-primary';
 
+    private local_apps_repo_name = '[data-testid="name-ns-description-name"]';
+    private local_apps_repo_url = '[data-testid="clusterrepo-git-repo-input"]';
+    private local_apps_repo_branch = '[data-testid="clusterrepo-git-branch-input"]';
+    private local_apps_repo_create = '[data-testid="action-button-async-button"]';
+
+    private extension_card_harvester_install = '[data-testid="extension-card-install-btn-harvester"]';
+    private install_harvester_extensionButton = '[data-testid="install-ext-modal-install-btn"]';
+    private extension_reloadButton = '[data-testid="extension-reload-banner-reload-btn"]';
+
+    private extension_installed_card_harvester = '[data-testid="extension-card-harvester"]';
+    private extension_card_harvester_uninstall = '[data-testid="extension-card-uninstall-btn-harvester"]';
+
     private cloudCredential_page_createButton = '.actions > .btn';
     private cloudCredential_page_harvester = '.subtypes-container > :nth-child(5)';
     private cloudCredential_page_clusterName = 'input[placeholder="A unique name"]';
@@ -183,6 +195,14 @@ export class rancherPage {
         cy.visit(constants.rancher_virtualizationManagement);
     }
 
+    public visit_local_cluster_repositories() {
+        cy.visit(constants.rancher_apps_repositories);
+    }
+
+    public visit_available_extensions() {
+        cy.visit(constants.rancher_available_extensions);
+    }
+
     public open_virtualizationDashboard() {
         cy.visit(constants.rancher_virtualizationManagement).then(() => {
             cy.log('visit virtualizationManagement');
@@ -202,6 +222,36 @@ export class rancherPage {
 
     public visit_nodeTemplate() {
         cy.visit(constants.rancher_nodeTamplatePage);
+    }
+
+    public add_local_cluster_repo(Repo_name: string, Repo_url: string, Repo_branch: string) {
+        // Visit the local cluster repository page
+        cy.visit(constants.rancher_apps_repositories + '/create');
+        cy.get(this.local_apps_repo_name).type(Repo_name);
+        // Select the Git repository option
+        const target = new RadioButtonPo('.radio-group');
+        target.input(/Git repository/);
+        // Input Git Repo URL and Branch to create the repository
+        cy.get(this.local_apps_repo_url).type(Repo_url);
+        cy.get(this.local_apps_repo_branch).type(Repo_branch);
+        cy.get(this.local_apps_repo_create).click();
+    }
+
+    public install_harvester_ui_extension(version: string) {
+        // Visit the Extension -> Available page
+        this.visit_available_extensions();
+        // Get the Harvester extension card and click the Install button
+        cy.get(this.extension_card_harvester_install).click();
+        // Search and select the version from the dropdown menu list
+        const versionSelect = new LabeledSelectPo('[data-testid="install-ext-modal-select-version"]');
+        versionSelect.select({ option: version, selector: '.vs__dropdown-menu' });
+        // Click the Install button to install the Harvester extension
+        cy.get(this.install_harvester_extensionButton).click();
+        cy.get(this.extension_reloadButton).click();
+        // Todo: Ensure the Harvester extension card exists
+        cy.get(this.extension_installed_card_harvester).should('exist', { timeout: constants.timeout.timeout });
+        // Todo: Ensure the Harvester extension card have the uninstall button
+        cy.get(this.extension_card_harvester_uninstall).should('exist', { timeout: constants.timeout.timeout });
     }
 
     public importHarvester() {

--- a/pageobjects/rancher.po.ts
+++ b/pageobjects/rancher.po.ts
@@ -250,6 +250,7 @@ export class rancherPage {
         cy.get(this.local_apps_repo_url).type(Repo_url);
         cy.get(this.local_apps_repo_branch).type(Repo_branch);
         cy.get(this.local_apps_repo_create).click();
+        cy.wait(5000);
     }
 
     public install_harvester_ui_extension(version: string) {
@@ -263,9 +264,9 @@ export class rancherPage {
         // Click the Install button to install the Harvester extension
         cy.get(this.install_harvester_extensionButton).click();
         cy.get(this.extension_reloadButton).click();
-        // Todo: Ensure the Harvester extension card exists
+        // Ensure the Harvester extension card exists
         cy.get(this.extension_installed_card_harvester).should('exist', { timeout: constants.timeout.timeout });
-        // Todo: Ensure the Harvester extension card have the uninstall button
+        // Ensure the Harvester extension card have the uninstall button
         cy.get(this.extension_card_harvester_uninstall).should('exist', { timeout: constants.timeout.timeout });
     }
 

--- a/testcases/rancher/rancher_integration.spec.ts
+++ b/testcases/rancher/rancher_integration.spec.ts
@@ -105,27 +105,29 @@ describe('Rancher Integration Test', function () {
     it('Add Harvester UI Extension Repository', { baseUrl: constants.rancherUrl }, () => {
         rancher.rancherLogin();
 
-        const serverInfo = rancher.getServerVersion();
-        Promise.resolve(serverInfo).then((infoBody) => {
+        cy.wrap(rancher.getServerVersion()).then((infoBody) => {
             cy.log(`Server Info: ${infoBody}`);
-            const parsedData = JSON.parse(infoBody);
-            rancherVersion = parsedData.Version;
-            cy.log(`Rancher version: ${rancherVersion}`);
+            try {
+                const parsedData = JSON.parse(infoBody as string);
+                rancherVersion = parsedData.Version;
+                cy.log(`Rancher version: ${rancherVersion}`);
 
-            const shouldSkipTest = rancherVersion.startsWith('v2.8') || rancherVersion.startsWith('v2.9');
-            onlyOn(!shouldSkipTest);
+                const shouldSkipTest = rancherVersion.startsWith('v2.8') || rancherVersion.startsWith('v2.9');
+                onlyOn(!shouldSkipTest);
 
-            // Continue with the rest of the test if not skipped
-            rancher.add_local_cluster_repo(
-                "harvester",
-                constants.rancher_ui_extension_repo_url,
-                constants.rancher_ui_extension_branch
-            );
-            cy.wait(5000);
-            rancher.visit_local_cluster_repositories();
-            rancher.checkState('harvester');
-            addUIextensionRepo = true;
-
+                // Continue with the rest of the test if not skipped
+                rancher.add_local_cluster_repo(
+                    "harvester",
+                    constants.harvester_ui_extension_repo_url,
+                    constants.harvester_ui_extension_branch,
+                );
+                rancher.visit_local_cluster_repositories();
+                rancher.checkState('harvester');
+                addUIextensionRepo = true;
+            } catch (e) {
+                cy.log('Failed to parse server version JSON: ' + (e instanceof Error ? e.message : e));
+                throw e; // Fail the test
+            }
         });
     });
 
@@ -141,7 +143,7 @@ describe('Rancher Integration Test', function () {
     it('Install Harvester UI Extension', { baseUrl: constants.rancherUrl }, () => {
         onlyOn(addUIextensionRepo);
         rancher.rancherLogin();
-        rancher.install_harvester_ui_extension(constants.rancher_ui_extension_version);
+        rancher.install_harvester_ui_extension(constants.harvester_ui_extension_version);
     });
 
     it('Rancher import Harvester', { baseUrl: constants.rancherUrl }, () => {

--- a/testcases/rancher/rancher_integration.spec.ts
+++ b/testcases/rancher/rancher_integration.spec.ts
@@ -110,6 +110,41 @@ describe('Rancher Integration Test', function () {
         page.firstTimeLogin();
     });
 
+    /**
+     * Add Harvester UI Extension Repository in Rancher local cluster for installation
+     * 1. Access Rancher local cluster Apps -> Repositories page
+     * 2. Create a new repository
+     * 3. Select the Git repository target
+     * 4. Input the Name, Git Repo URL and Branch
+     * 5. Ensure the new repository in Active state
+     */
+    it('Add Harvester UI Extension Repository', { baseUrl: constants.rancherUrl }, () => {
+        rancher.rancherLogin();
+        rancher.add_local_cluster_repo(
+            "harvester",
+            constants.rancher_ui_extension_repo_url,
+            constants.rancher_ui_extension_branch
+        );
+        cy.wait(5000);
+        rancher.visit_local_cluster_repositories();
+        rancher.checkState('harvester');
+
+    });
+
+    /**
+     * Install Harvester UI Extension in the Extensions -> available page
+     * 1. Visit the Extension -> Available page
+     * 2. Get the Harvester extension card and click the Install button
+     * 3. Search and select the version from the dropdown menu list
+     * 4. Click the Install button to install the Harvester extension
+     * 5. Ensure the Harvester extension card exists
+     * 6. Ensure the Harvester extension card have the uninstall button
+     */
+    it('Install Harvester UI Extension', { baseUrl: constants.rancherUrl }, () => {
+        rancher.rancherLogin();
+        rancher.install_harvester_ui_extension(constants.rancher_ui_extension_version);
+    });
+
     it('Rancher import Harvester', { baseUrl: constants.rancherUrl }, () => {
         rancher.rancherLogin();
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
* Issue : https://github.com/harvester/tests/issues/2035

#### What this PR does / why we need it:

Starting from Rancher `v2.10.1`, we introduced [harvester-ui-extension](https://docs.harvesterhci.io/v1.4/rancher/harvester-ui-extension/) for  Rancher virtualization management.

We need to add new cypress test can install the `harvester-ui-extension` from the Rancher Extension page.

### Support matrix
1. Harvester v1.4.x: https://docs.harvesterhci.io/v1.4/rancher/harvester-ui-extension/
2. Harvester v1.5.x: https://docs.harvesterhci.io/v1.5/rancher/harvester-ui-extension/

### Test scope

1. Latest Rancher v2.10.x , v2.11.x and v2.9.x
2. Latest Harvester v1.5.0 and v1.4.3
3. Different harvester-ui-extension version, v1.0.x and v1.5.x

#### Changes
Add the following tests prior to import Harvester to Rancher 
1. Add Harvester UI Extension Repository
    - This will add the Harvester UI extension repository in the Rancher local cluster -> Apps -> Repositories page
    - Use three constant parameters in the `cypress.env.json.example` file
      - "ui_extension_repo_url"
      - "ui_extension_branch"
      - "ui_extension_version"
    -  Ensure the new repository in Active state

2. Install Harvester UI Extension
    - According the version number to search and select the version from the dropdown menu list
    - After installation complete, ensure the Harvester extension card exists
    - Ensure the Harvester extension card have the uninstall button

3. Add check Rancher version mechanism to determine whether to execute or skip add repository and install ui extension tests
   - When Rancher version start with v2.8 and v2.9 -> skip these tests
   - Rancher version not in 2.8 and 2.9 -> execute these tests

#### Test Result - fixed the following test cases:

* Verified can PASS all Rancher integration tests on Rancher `v2.10.5` -> Install UI Extension


  https://github.com/user-attachments/assets/33499053-0afc-48e3-8d2d-b3a8b6e43c2d




* Verified can PASS all Rancher integration tests on Rancher `v2.11.0` -> Install UI Extension


  https://github.com/user-attachments/assets/294ae9e6-d625-4904-ad2e-c41192bad140


* Verified can PASS all Rancher integration tests on Rancher `v2.9.7` -> Skip to add repository and install UI extension


  https://github.com/user-attachments/assets/8c79ad54-8616-4759-8720-826f49192f6b


