### PR TITLE
Add first vm migration test and related image and network tests

### DIFF
--- a/pageobjects/image.po.ts
+++ b/pageobjects/image.po.ts
@@ -34,7 +34,7 @@ export class ImagePage extends CruResourcePo {
     return new LabeledInputPo('.labeled-input', `:contains("URL")`);
   }
 
-  setBasics({url, path} : { url?: string, path?: string }) {
+  setBasics({ url, path }: { url?: string, path?: string }) {
     this.clickTab('basic');
 
     if (path) {
@@ -49,9 +49,9 @@ export class ImagePage extends CruResourcePo {
     }
   }
 
-  setLabels({labels = {}} : {labels?: any}) {
+  setLabels({ labels = {} }: { labels?: any }) {
     const keys = Object.keys(labels);
-    
+
     this.clickTab('labels');
     keys.forEach((key, index) => {
       cy.contains('Add Label').click();
@@ -64,7 +64,7 @@ export class ImagePage extends CruResourcePo {
   filterByLabels(labels: any = {}) {
     const keys = Object.keys(labels);
 
-    cy.get('body').click(500,0);
+    cy.get('body').click(500, 0);
     cy.get('.fixed-header-actions').contains('Filter labels').click();
     cy.get('.filter-popup').contains('Clear All').click();
 
@@ -72,23 +72,28 @@ export class ImagePage extends CruResourcePo {
       cy.get('.filter-popup').contains('Add').click();
       cy.get('.filter-popup .box').eq(index + 1).within(() => {
         const keyInput = new LabeledSelectPo('.key .unlabeled-select');
-        
-        keyInput.select({option: key});
-        
+
+        keyInput.select({ option: key });
+
         const valueInput = new LabeledSelectPo('.value .unlabeled-select');
-        
+
         if (labels[key]) {
-          valueInput.select({option: labels[key]});
+          valueInput.select({ option: labels[key] });
         }
       })
     });
-    
+
   }
 
-  checkState({ name = '', namespace = 'default', state = 'Active', progress = 'Completed', size = '16 Mi' }: {name?:string, namespace?:string, state?:string, progress?:string,size?:string} = {}) {
+  checkState({ name = '', namespace = 'default', state = 'Active', progress = 'Completed', size = '16 Mi' }: { name?: string, namespace?: string, state?: string, progress?: string, size?: string } = {}) {
     this.censorInColumn(name, 3, namespace, 4, state, 2, { timeout: constants.timeout.downloadTimeout });
     this.censorInColumn(name, 3, namespace, 4, progress, 6, { timeout: constants.timeout.downloadTimeout });
     this.censorInColumn(name, 3, namespace, 4, size, 7, { timeout: constants.timeout.downloadTimeout });
+  }
+
+  checkState_without_size({ name = '', namespace = 'default', state = 'Active', progress = 'Completed' }: { name?: string, namespace?: string, state?: string, progress?: string } = {}) {
+    this.censorInColumn(name, 3, namespace, 4, state, 2, { timeout: constants.timeout.downloadTimeout });
+    this.censorInColumn(name, 3, namespace, 4, progress, 6, { timeout: constants.timeout.downloadTimeout });
   }
 
   public exportImage(vmName: string, imageName: string, namespace: string) {
@@ -107,21 +112,21 @@ export class ImagePage extends CruResourcePo {
     })
   }
 
-  public save( { upload, edit, depth }: { namespace?:string, buttonText?: string, upload?: boolean; edit?: boolean; depth?: number; } = {} ): Promise<string> {
+  public save({ upload, edit, depth }: { namespace?: string, buttonText?: string, upload?: boolean; edit?: boolean; depth?: number; } = {}): Promise<string> {
     return new Promise((resolve, reject) => {
       const interceptName = generateName('create');
 
-      cy.intercept(edit? 'PUT' : 'POST', `/v1/harvester/harvesterhci.io.virtualmachineimages${ upload ? '/*' : edit ? '/*/*' : '' }`).as(interceptName);
+      cy.intercept(edit ? 'PUT' : 'POST', `/v1/harvester/harvesterhci.io.virtualmachineimages${upload ? '/*' : edit ? '/*/*' : ''}`).as(interceptName);
       cy.get('.cru-resource-footer').contains(!edit ? 'Create' : 'Save').click();
       cy.wait(`@${interceptName}`).then(async (res) => {
         if (edit && res.response?.statusCode === 409 && depth === 0) {
-          await this.save({ upload, edit, depth: depth + 1})
+          await this.save({ upload, edit, depth: depth + 1 })
         } else {
-          expect(res.response?.statusCode, `Check save success`).to.equal( edit ? 200 : 201 );
+          expect(res.response?.statusCode, `Check save success`).to.equal(edit ? 200 : 201);
           resolve(res.response?.body?.metadata?.name || '');
         }
       })
-      .end();
+        .end();
     });
   }
 }

--- a/pageobjects/network.po.ts
+++ b/pageobjects/network.po.ts
@@ -1,8 +1,11 @@
+import { Constants } from "@/constants/constants";
 import LabeledInputPo from '@/utils/components/labeled-input.po';
 import LabeledSelectPo from '@/utils/components/labeled-select.po';
 import RadioButtonPo from '@/utils/components/radio-button.po';
 import { HCI, NETWORK_ATTACHMENT } from '@/constants/types'
 import CruResourcePo from '@/utils/components/cru-resource.po';
+
+const constants = new Constants();
 
 interface ValueInterface {
   namespace: string,
@@ -74,6 +77,13 @@ export default class NetworkPage extends CruResourcePo {
       clusterNetwork,
     });
 
+  }
+
+  checkVlanState({ name = '', namespace = 'default', state = 'Active', routeConnectivity = 'Active', vlanID = '', clusterNetwork = '' }: { name?: string, namespace?: string, state?: string, routeConnectivity?: string, vlanID?: string, clusterNetwork?: string } = {}) {
+    this.censorInColumn(name, 3, namespace, 4, state, 2, { timeout: constants.timeout.downloadTimeout });
+    this.censorInColumn(name, 3, namespace, 4, clusterNetwork, 6, { timeout: constants.timeout.downloadTimeout });
+    this.censorInColumn(name, 3, namespace, 4, vlanID, 7, { timeout: constants.timeout.downloadTimeout });
+    this.censorInColumn(name, 3, namespace, 4, routeConnectivity, 8, { timeout: constants.timeout.downloadTimeout });
   }
 
 }

--- a/pageobjects/virtualmachine.po.ts
+++ b/pageobjects/virtualmachine.po.ts
@@ -288,7 +288,6 @@ export class VmsPage extends CruResourcePo {
     } else {
       cy.get('.tab#Network').click()
 
-      // cy.get('.info-box.infoBox').then(elms => {
       cy.get('[data-testid="input-hen-networkName"]').then(elms => {
         if (elms?.length < networks?.length) {
           for (let i = 0; i < networks?.length - elms?.length; i++) {
@@ -482,17 +481,18 @@ export class VmsPage extends CruResourcePo {
 
     // Get IP address and execute SSH command
     cy.contains('tr', vmName)
-      .wait(10000) // Wait for system ssh port ready
       .find('[data-title="IP Address"] > div > span > .copy-to-clipboard-text')
       .then($els => {
         const address = $els[0]?.innerText;
 
-        cy.task('sshWithPassword', {
-          username,
-          password,
-          host: address,
-          remoteCommand,
-        })
+        // Use Cypress's built-in retry mechanism with should()
+        cy.wrap(null).should(() => {
+          cy.task('sshWithPassword', {
+            username,
+            password,
+            host: address,
+            remoteCommand,
+          })
           .then((result: any) => {
             cy.log(`SSH result: ${JSON.stringify(result)}`);
 
@@ -505,6 +505,7 @@ export class VmsPage extends CruResourcePo {
             }
             // If checkResult is false, just log the result and continue
           });
+        });
       });
   }
 

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -110,6 +110,36 @@ module.exports = (on, config) => {
         })
       })
     },
+    // Add this new task for password authentication
+    sshWithPassword ({username, password, host='', remoteCommand}) { 
+      return new Promise((resolve, reject) => {
+        const {NodeSSH} = require('node-ssh')
+        const ssh = new NodeSSH()
+
+        ssh.connect({   
+          host: host.trim(),
+          username,
+          password,
+          port: 22,
+          readyTimeout: 60000,
+        })
+        .then(function() {
+          ssh.execCommand(remoteCommand)
+            .then(function(result) {
+              ssh.dispose();
+              resolve(result)
+            })
+            .catch((err) => {
+              ssh.dispose();
+              reject(err)
+            })
+        })
+        .catch(err => {
+          ssh.dispose();
+          reject(err)
+        })
+      })
+    },
 })
 
   // https://github.com/cypress-io/cypress/issues/349

--- a/testcases/image/images.spec.ts
+++ b/testcases/image/images.spec.ts
@@ -61,8 +61,11 @@ describe('Auto setup image from cypress environment', () => {
  */
 describe('Create an image with valid image URL', () => {
     const imageEnv = Cypress.env('image');
+    const largeImageEnv = Cypress.env('largeImage');
     const IMAGE_NAME = generateName('auto-image-valid-url-test');
     const IMAGE_URL = imageEnv.url;
+    const LARGE_IMAGE_NAME = largeImageEnv.name;
+    const LARGE_IMAGE_URL = largeImageEnv.url;
 
     it('Create an image with valid image URL', () => {
         cy.login();
@@ -111,6 +114,25 @@ describe('Create an image with valid image URL', () => {
             image.delete(namespace, realName as string, IMAGE_NAME);
         })
     });
+
+    it('Create an image with large image URL', () => {
+        cy.login();
+
+        // create IMAGE
+        const namespace = 'default';
+
+        image.goToCreate();
+        image.setNameNsDescription(LARGE_IMAGE_NAME, namespace);
+        image.setBasics({ url: LARGE_IMAGE_URL });
+
+        cy.wrap(image.save()).then((realName) => {
+            // check IMAGE state
+            image.checkState_without_size({ name: LARGE_IMAGE_NAME });
+
+        })
+
+    });
+
 });
 
 /**
@@ -389,7 +411,7 @@ describe('Clone image', () => {
         image.checkState({ name: CLONED_NAME });
         image.goToEdit(CLONED_NAME);
         image.clickTab('labels');
-        
+
         cy.get('.tab-container .kv-item.value input[type="text"]').eq(1).should('have.value', CLONED_NAME);
 
         cy.wrap(null).then(() => {

--- a/testcases/networks/network.spec.ts
+++ b/testcases/networks/network.spec.ts
@@ -152,7 +152,7 @@ describe('Preset Vlans', () => {
     })
   }
 
-  it('Create Vlan1', () => {
+  it('Create first Vlan', () => {
     const vlans = Cypress.env('vlans') || [];
     const vlan = vlans[0].vlan
 
@@ -166,7 +166,7 @@ describe('Preset Vlans', () => {
     })
   });
 
-  it('Create Vlan2', () => {
+  it('Create second Vlan', () => {
     const vlans = Cypress.env('vlans') || [];
     const vlan = vlans[1].vlan
 
@@ -178,5 +178,29 @@ describe('Preset Vlans', () => {
       vlan,
       clusterNetwork: 'mgmt',
     })
+  });
+
+  it('Create Vlan with id 1', () => {
+    const vlans = Cypress.env('vlans') || [];
+    const vlan = 1
+
+    cy.login();
+
+    createVlan({
+      name: `vlan${vlan}`,
+      namespace: 'default',
+      vlan,
+      clusterNetwork: 'mgmt',
+    })
+
+    network.checkVlanState({
+      name: `vlan${vlan}`,
+      namespace: 'default',
+      state: 'Active',
+      routeConnectivity: 'Active',
+      vlanID: `${vlan}`,
+      clusterNetwork: 'mgmt',
+    });
+
   });
 });

--- a/testcases/virtualmachines/vm-migration.spec.ts
+++ b/testcases/virtualmachines/vm-migration.spec.ts
@@ -1,0 +1,150 @@
+import { VmsPage } from "@/pageobjects/virtualmachine.po";
+import { VolumePage } from "@/pageobjects/volume.po";
+import NamespacePage from "@/pageobjects/namespace.po";
+import { PageUrl } from "@/constants/constants";
+import { ImagePage } from "@/pageobjects/image.po";
+import { generateName } from '@/utils/utils';
+import { Constants } from "@/constants/constants";
+import { host as hostUtil } from '@/utils/utils';
+
+const vms = new VmsPage();
+const volumePO = new VolumePage();
+const constants = new Constants();
+const namespaces = new NamespacePage();
+const imagePO = new ImagePage();
+
+/**
+ * @module testcases/virtualmachines/vm-migration.spec.ts
+ * @description This module contains test cases for virtual machine migration and related functionalities.
+ */
+describe('VM Live Migration', () => {
+  beforeEach(() => {
+    cy.login({ url: PageUrl.virtualMachine });
+  });
+
+  /**
+   * 1. Navigate to the VM create page
+   * 2. Create a new VM with cloud init config data
+   * 3. ssh to the vm and create a new file
+   * 4. Get the original node name before migration
+   * 5. Migrate the VM to another host
+   *  - VM should go into migrating status
+   * 6. Check can correctly migrate to other node
+   * 7. VM migrated should be in running state
+   * 8. ssh to the vm, check the file content is the same
+  */
+  it.only('Migrate VM with cloud init data', () => {
+    const VM_NAME = generateName('test-vm-migrate');
+    const NAMESPACE = 'default'
+    const NETWORK = 'vlan1'
+    const largeImageEnv = Cypress.env('largeImage');;
+    const USERDATA = `#cloud-config
+password: password
+chpasswd: { expire: False }
+sshpwauth: True
+`
+
+    const value = {
+      name: VM_NAME,
+      cpu: '1',
+      memory: '2',
+      image: largeImageEnv.name,
+      networks: [{
+        network: NETWORK,
+      }],
+      guestAgent: true,
+      namespace: NAMESPACE,
+      userData: USERDATA,
+    }
+    vms.create(value);
+
+    // Check VM is running
+    vms.censorInColumn(VM_NAME, 3, NAMESPACE, 4, 'Running', 2, { timeout: constants.timeout.maxTimeout, nameSelector: '.name-console a' });
+    // Wait for IP address show in table
+    vms.censorInColumn(VM_NAME, 3, NAMESPACE, 4, '.', 7, { timeout: constants.timeout.maxTimeout, nameSelector: '.name-console a' });
+
+    // Check VM display IP address and ssh to the VM
+    cy.contains('tr', VM_NAME)
+      .wait(10000) // Wait for system ssh port ready
+      .find('[data-title="IP Address"] > div > span > .copy-to-clipboard-text')
+      .then($els => {
+        const address = $els[0]?.innerText
+
+        vms.sshWithCommand(
+          VM_NAME,
+          'opensuse',
+          'password',
+          'echo "content before migration" > migrate-vm.txt',
+          false  // Don't check the output
+        );
+
+      })
+
+    // Get the original node name before migration
+    cy.contains('tr', VM_NAME)
+      .find('td')
+      .eq(7) // Node column
+      .invoke('text')
+      .then((nodeName) => {
+        const originalNode = nodeName.trim();
+        cy.log(`VM is currently running on node: ${originalNode}`);
+
+        // Find the first node that doesn't match the original node
+        const targetNode = hostUtil.list().find(host => {
+          const hostName = host.name || host.customName;
+          return hostName !== originalNode;
+        })?.name || hostUtil.list().find(host => {
+          const hostName = host.name || host.customName;
+          return hostName !== originalNode;
+        })?.customName;
+
+        cy.log(`Target node for migration: ${targetNode}`);
+
+        // Store both nodes for later comparison
+        cy.wrap(originalNode).as('originalNode');
+        cy.wrap(targetNode).as('targetNode');
+
+        // Perform migration with the found target node
+        vms.clickMigrateAction(VM_NAME, `${targetNode}`);
+
+        // Check VM in migrating state
+        vms.censorInColumn(VM_NAME, 3, NAMESPACE, 4, 'Migrating', 2, {
+          timeout: constants.timeout.maxTimeout,
+          nameSelector: '.name-console a'
+        });
+
+        // Check VM in running state
+        vms.censorInColumn(VM_NAME, 3, NAMESPACE, 4, 'Running', 2, {
+          timeout: constants.timeout.maxTimeout,
+          nameSelector: '.name-console a'
+        });
+
+        // Verify migration was successful
+        cy.contains('tr', VM_NAME)
+          .find('td')
+          .eq(7)
+          .invoke('text')
+          .then((newNodeName) => {
+            const currentNode = newNodeName.trim();
+            expect(currentNode).to.equal(targetNode);
+            expect(currentNode).to.not.equal(originalNode);
+            cy.log(`Migration successful: ${originalNode} → ${currentNode}`);
+
+          });
+      });
+
+    // Check the file content not changed after migration  
+    vms.sshWithCommand(
+      VM_NAME,
+      'opensuse',
+      'password',
+      'cat migrate-vm.txt',
+      false,  // Don't check the output
+      'content before migration'
+    );
+    // tear down
+    vms.delete(NAMESPACE, VM_NAME)
+
+  });
+
+})

--- a/testcases/virtualmachines/vm-migration.spec.ts
+++ b/testcases/virtualmachines/vm-migration.spec.ts
@@ -33,7 +33,7 @@ describe('VM Live Migration', () => {
    * 7. VM migrated should be in running state
    * 8. ssh to the vm, check the file content is the same
   */
-  it.only('Migrate VM with cloud init data', () => {
+  it('Migrate VM with cloud init data', () => {
     const VM_NAME = generateName('test-vm-migrate');
     const NAMESPACE = 'default'
     const NETWORK = 'vlan1'

--- a/testcases/virtualmachines/vm-migration.spec.ts
+++ b/testcases/virtualmachines/vm-migration.spec.ts
@@ -37,7 +37,7 @@ describe('VM Live Migration', () => {
     const VM_NAME = generateName('test-vm-migrate');
     const NAMESPACE = 'default'
     const NETWORK = 'vlan1'
-    const largeImageEnv = Cypress.env('largeImage');;
+    const largeImageEnv = Cypress.env('largeImage');
     const USERDATA = `#cloud-config
 password: password
 chpasswd: { expire: False }
@@ -139,7 +139,7 @@ sshpwauth: True
       'opensuse',
       'password',
       'cat migrate-vm.txt',
-      false,  // Don't check the output
+      true,  // Don't check the output
       'content before migration'
     );
     // tear down


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
* Issue : https://github.com/harvester/tests/issues/1547

#### What this PR does / why we need it:
Currently we not yet have frontend automation to test the virtual machine live migration feature in Harvester.

According to the issue description, add the first basic vm migration test plan with steps:

1. Migrate VM with cloud init data

   -  Navigate to the VM create page
   -  Create a new VM with cloud init config data
   -  ssh to the vm and create a new file
   -  Get the original node name before migration
   -  Migrate the VM to another host
       -  VM should go into migrating status
   -  Check can correctly migrate to other node
   -  VM migrated should be in running state
   -  ssh to the vm, check the file content is the same

And in order to let the virtual machine under test can get outbound IP address.

I also add one image test to use the correct oepnSUSE Leap image and another network test to create the `vlan1` network. These are must have prerequisite to make the vm migration work. 

1. `Create an image with large image URL`
2. `Create Vlan with id 1`

For these tests can execute well on the Jenkins pipeline, we also need to ensure the large image parameter have been updated as stated in the pull request
* https://github.com/harvester/harvester-baremetal-ansible/pull/100

#### Test reminder 
Must have environment parameters to run the vm migration test.

1. Provide the correct host name information in the `cypress.env.json` 

    ```
      "host": [
          {
          "name": "harvester-node-0",
          "customName": "test-custom-name",
          "disks": [
            {
              "name": "/dev/vda",
              "devPath": "/dev/vda"
            }
          ],
          "witnessNode": false
        },      {
          "name": "harvester-node-1",
          "customName": "",
          "disks": [
            {
              "name": "/dev/vda",
              "devPath": "/dev/vda"
            }
          ],
          "witnessNode": false
        },      {
          "name": "harvester-node-2",
          "customName": "",
          "disks": [
            {
              "name": "/dev/vda",
              "devPath": "/dev/vda"
            }
          ],
          "witnessNode": false
        }    ],
      ```

2. Provide the largeImage environment parameters in the `cypress.env.json`

      ```
      "largeImage": {
        "name": "openSUSE-Leap-15.3-3-NET-x86_64.qcow2",
        "url": "https://download.opensuse.org/pub/opensuse/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-OpenStack-Cloud-Current.qcow2"
      },
      ```

#### Test Result - fixed the following test cases:

* Verified the `happy path` of vm migration test on Harvester `v1.5.1-rc2`

https://github.com/user-attachments/assets/17057612-bd96-463a-8b03-28a62024b5a5



* Verified the `failure path` of vm migration test on Harvester `v1.5.1-rc3`

https://github.com/user-attachments/assets/69e91371-507a-4cfd-bc47-abd6dbe2621b


* Create large image test


https://github.com/user-attachments/assets/52900fec-88d0-4d12-bd4c-fab2f5de88c5


* Create vlan 1 network test

https://github.com/user-attachments/assets/1d9e8318-61a3-4c16-8c9a-a44d44716936



