### PR TITLE
Fix flaky failed tests on Harvester v1.6.0-rc5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ docs
 cypress.env.json
 cypress/*
 *.mp4
+results/
+CLAUDE.md

--- a/pageobjects/virtualmachine.po.ts
+++ b/pageobjects/virtualmachine.po.ts
@@ -142,7 +142,7 @@ export class VmsPage extends CruResourcePo {
 
   checkVMState(name: string, state: string = 'Running', namespace: string = 'default') {
     this.goToList();
-    this.censorInColumn(name, 3, namespace, 4, state, 2, { timeout: constants.timeout.uploadTimeout, nameSelector: '.name-console a' });
+    this.censorInColumn(name, 3, namespace, 4, state, 2, { timeout: constants.timeout.provisionTimeout, nameSelector: '.name-console a' });
   }
 
   clickCloneAction(name: string) {

--- a/pageobjects/virtualmachine.po.ts
+++ b/pageobjects/virtualmachine.po.ts
@@ -440,6 +440,7 @@ export class VmsPage extends CruResourcePo {
     cy.wait(2000);
     cy.wrap(volumeNames).each((V: string) => {
       // reload the page before plugging a new volume
+      cy.wait(5000);
       cy.reload()
       this.clickAction(vmName, 'Add Volume').then((_) => {
         cy.get('.modal-container .card-container').within(() => {

--- a/testcases/dashboard/hosts.spec.ts
+++ b/testcases/dashboard/hosts.spec.ts
@@ -33,6 +33,7 @@ describe('should insert custom name into YAML', () => {
 
     // Revert the custom change
     hosts.goToEdit(customName);
+    cy.reload();
     hosts.cleanValue();
     hosts.update(host.name);
   });

--- a/testcases/templates/advanced.spec.ts
+++ b/testcases/templates/advanced.spec.ts
@@ -43,7 +43,7 @@ describe("template with EFI", () => {
 
     vmPO.selectTemplateAndVersion({id: `${namespace}/${NAME}`, version: '1'})
 
-    const namePrefix = 'test-multiple-efi'
+    const namePrefix = generateName('test-multiple-efi')
 
     vmPO.setMultipleInstance({
       namePrefix,

--- a/testcases/virtualmachines/advanced.spec.ts
+++ b/testcases/virtualmachines/advanced.spec.ts
@@ -149,9 +149,9 @@ describe("Verify Booting in EFI mode checkbox", () => {
 
     vms.goToCreate();
 
-    const namePrefix = 'test-multiple-instances'
+    const namePrefix = generateName('test-multiple-instances')
     const namespace = 'default'
-    const vmCount = 3
+    const vmCount = 2
     const imageEnv = Cypress.env('image');
     const userData = `#cloud-config
 password: password

--- a/testcases/virtualmachines/advanced.spec.ts
+++ b/testcases/virtualmachines/advanced.spec.ts
@@ -138,9 +138,9 @@ describe("Verify Booting in EFI mode checkbox", () => {
  * chpasswd: {expire: False}
  * sshpwauth: True
  * ```
- * 4. Create the 2 vms and wait for vm to start.
+ * 3. Create the 2 vms and wait for vm to start.
  * Expected Results
- * 5. 2 vms should come up and start with same config.
+ * 4. 2 vms should come up and start with same config.
  */
  describe("Create multiple instances of the vm with raw image", () => {
   it('Create multiple instances of the vm with raw image', () => {

--- a/testcases/virtualmachines/advanced.spec.ts
+++ b/testcases/virtualmachines/advanced.spec.ts
@@ -132,16 +132,15 @@ describe("Verify Booting in EFI mode checkbox", () => {
 /**
  * 1. Create images using the external path for cloud image.
  * 2. In user data mention the below to access the vm.
- * 3.
  * ```
  * #cloud-config
  * password: password
  * chpasswd: {expire: False}
  * sshpwauth: True
  * ```
- * 4. Create the 3 vms and wait for vm to start.
+ * 4. Create the 2 vms and wait for vm to start.
  * Expected Results
- * 1. 3 vm should come up and start with same config.
+ * 5. 2 vms should come up and start with same config.
  */
  describe("Create multiple instances of the vm with raw image", () => {
   it('Create multiple instances of the vm with raw image', () => {

--- a/testcases/virtualmachines/node-scheduling.spec.ts
+++ b/testcases/virtualmachines/node-scheduling.spec.ts
@@ -42,6 +42,7 @@ describe('Stop VM Negative', () => {
 
     // Stop VM and validate status is Off
     vmPO.clickAction(VM_NAME, 'Stop');
+    cy.reload();
     vmPO.censorInColumn(VM_NAME, 3, namespace, 4, 'Off', 2, {
         nameSelector: '.name-console a',
         timeout: constants.timeout.uploadTimeout,

--- a/testcases/virtualmachines/node-scheduling.spec.ts
+++ b/testcases/virtualmachines/node-scheduling.spec.ts
@@ -40,9 +40,9 @@ describe('Stop VM Negative', () => {
       timeout: constants.timeout.uploadTimeout,
     });
 
-    // Stop VM and validate status
+    // Stop VM and validate status is Off
     vmPO.clickAction(VM_NAME, 'Stop');
-    vmPO.censorInColumn(VM_NAME, 3, namespace, 4, 'Stopping', 2, {
+    vmPO.censorInColumn(VM_NAME, 3, namespace, 4, 'Off', 2, {
         nameSelector: '.name-console a',
         timeout: constants.timeout.uploadTimeout,
     });

--- a/testcases/virtualmachines/vm-migration.spec.ts
+++ b/testcases/virtualmachines/vm-migration.spec.ts
@@ -58,6 +58,9 @@ sshpwauth: True
     }
     vms.create(value);
 
+    // Navigate to VM list to ensure we're on the correct page
+    vms.goToList();
+
     // Check VM is running
     vms.censorInColumn(VM_NAME, 3, NAMESPACE, 4, 'Running', 2, { timeout: constants.timeout.maxTimeout, nameSelector: '.name-console a' });
     // Wait for IP address show in table


### PR DESCRIPTION
### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
* Issue : https://github.com/harvester/tests/issues/2120

### What this PR does / why we need it:

From Harvester v1.6.0-rc5, there are still some failed cypress test result.

According to the first test report in:

* http://10.115.1.7/job/harvester-cypress-test/40/HTML_20Report/

There are **5** Failed tests, these failed tests are:

1. should insert custom name into YAML
2. Check edit host
3. Stop VM Negative
4. VM scheduling on Specific node
5. Migrate VM with cloud init data

Then According to the second test report in:

There are **3** Failed tests, these failed tests are:

1. Restore new VM from vm backup
2. Stop VM Negative
3. Migrate VM with cloud init data

We need to enhance the cypress test script to make these test execution more stable

### Test Result - fixed the following test cases:

On the latest cypress test report on v1.6.0-rc5 

* http://10.115.1.7/job/harvester-cypress-test/43/HTML_20Report/

There is only one failed test `Support Volume Hot Unplug` and all previous failed test are passed

  <img width="1600" height="790" alt="image" src="https://github.com/user-attachments/assets/2828ef96-80f0-47f0-94b1-2b6cc9875aed" />

