### PR TITLE
[main] Add create cluster network and network config tests

### DIFF
--- a/constants/constants.ts
+++ b/constants/constants.ts
@@ -40,6 +40,7 @@ export const PageUrl = {
     setting: '/harvester/c/local/harvesterhci.io.setting',
     virtualMachine: '/harvester/c/local/kubevirt.io.virtualmachine',
     vmNetwork: '/harvester/c/local/harvesterhci.io.networkattachmentdefinition',
+    clusterNetwork: '/harvester/c/local/network.harvesterhci.io.clusternetwork',
     namespace: '/harvester/c/local/namespace',
     volumeSnapshot: '/harvester/c/local/harvesterhci.io.volumesnapshot'
 }

--- a/pageobjects/clusterNetwork.po.ts
+++ b/pageobjects/clusterNetwork.po.ts
@@ -5,11 +5,27 @@ import CruResource from '@/utils/components/cru-resource.po';
 import { HCI } from '@/constants/types'
 const constants = new Constants();
 
-export default class SettingsPagePo extends CruResource {
+export default class clusterNetworkPage extends CruResource {
     private detailPageHead = 'main .outlet header h1 a';
 
     constructor() {
-       super({ type: HCI.CLUSTER_NETWORK })
+        super({ type: HCI.CLUSTER_NETWORK })
+    }
+
+
+    NICs() {
+        return new LabeledSelectPo('[data-testid="array-list-box0"]')
+    }
+
+    /**
+     * Create a cluster network with the given name.
+     * If no name is provided, defaults to 'cn'.
+     * This wraps the common create flow used in tests.
+     */
+    public createClusterNetwork(name: string = 'cn') {
+        this.goToCreate();
+        this.name().input(name);
+        this.save();
     }
 
     /**
@@ -18,11 +34,71 @@ export default class SettingsPagePo extends CruResource {
     public clickMenu(name: string, actionText: string, urlSuffix: string, type: string) {
         const editPageUrl = type || constants.settingsUrl;
         cy.get(`.advanced-setting #${name} button`).click()
-  
+
         cy.get('span').contains(actionText).click();
-        
+
         cy.get(this.detailPageHead).then(() => {
-            cy.url().should('eq', `${this.basePath()}${editPageUrl}/${urlSuffix}?mode=edit`)
+                cy.url().should('eq', `${this.basePath()}${editPageUrl}/${urlSuffix}?mode=edit`)
         })
+    }
+
+    /**
+     * Navigate to the Cluster Network list and assert the given name is visible.
+     * @param name - resource name to look for in the table
+     * @param timeout - optional timeout in ms (defaults to constants.timeout.maxTimeout)
+     */
+    public checkClusterNetwork(name: string, timeout: number = constants.timeout.maxTimeout) {
+        this.goToList();
+        cy.get('table').contains('td', name, { timeout }).should('be.visible');
+    }
+
+    /**
+     * Create a network configuration under a cluster network.
+     * @param name - network configuration name
+     * @param nicName - NIC name to select for the uplink
+     */
+    public createNetworkConfig(name: string, nicName: string) {
+        this.goToList();
+        this.clickCreateNetworkConfigButton();
+        this.name().input(name);
+        this.clickUplinkTab();
+        this.selectNIC(nicName);
+        this.clickFooterBtn('save');
+    }
+
+    /**
+     * Click the "Create Network Configuration" button
+     */
+    public clickCreateNetworkConfigButton() {
+        cy.contains('a', 'Create Network Configuration').click();
+    }
+
+    /**
+     * Click the Uplink tab
+     */
+    public clickUplinkTab() {
+        cy.get('[data-testid="upLink"]').click();
+    }
+
+    /**
+     * Select a NIC from the dropdown
+     * @param nicName - the NIC name to select (e.g., "ens6 (Up)")
+     */
+    public selectNIC(nicName: string) {
+        this.NICs().select({ option: nicName });
+    }
+
+    /**
+     * Check that a network config exists under the specified cluster network panel
+     * @param configName The name of the network configuration
+     * @param clusterNetworkName The name of the cluster network
+     */
+    public checkNetworkConfig(configName: string, clusterNetworkName: string) {
+        this.goToList();
+        cy.contains('.group-tab', `Cluster Network: ${clusterNetworkName}`)
+          .parents('tbody.group')
+          .find('.main-row')
+          .contains('td', configName)
+          .should('be.visible');
     }
 }

--- a/testcases/networks/cluster-network.spec.ts
+++ b/testcases/networks/cluster-network.spec.ts
@@ -1,0 +1,50 @@
+import clusterNetworkPage from '@/pageobjects/clusterNetwork.po';
+import { PageUrl } from "@/constants/constants";
+import { onlyOn } from "@cypress/skip-test";
+
+const clusterNetwork = new clusterNetworkPage();
+
+let clusterNetworkCreated: boolean = false;
+
+beforeEach(() => {
+    cy.login({url: PageUrl.clusterNetwork});
+});
+
+/**
+ * 1. Login
+ * 2. Navigate to the Networks -> Cluster Network Configuration page
+ * 3. Click the `Create a Cluster Network` button
+ * 4. Input name `cn`
+ * 5. Click the create button
+ * 6. Check the `cn` cluster network display on the Cluster Network Configuration list 
+ */
+describe('Cluster Network Configuration', () => {
+  it('Create cluster network', () => {
+
+    clusterNetwork.createClusterNetwork('cn');
+
+    clusterNetwork.checkClusterNetwork('cn');
+
+    clusterNetworkCreated = true;
+  });
+
+  /**
+   * Depends on previous test creating cluster network 'cn'
+   * 1. Login
+   * 2. Navigate to the Networks -> Cluster Network Configuration page
+   * 3. Check the cluster network `cn` exists from previous test result
+   * 4. Click the `Create Network Config` button
+   * 5. Input the Name `nc` of the Network Config
+   * 6. Click the Uplink tab
+   * 7. Click to select the `ens6 (Up)` from the NICs dropdown list
+   * 8. Click the create button
+   * 9. Check the network config named `nc` exists under the `cn` cluster network panel 
+   */
+  it('Create network configuration', () => {
+    onlyOn(clusterNetworkCreated);
+
+    clusterNetwork.createNetworkConfig('nc', 'ens6 (Up)');
+
+    clusterNetwork.checkNetworkConfig('nc', 'cn');
+  });
+});


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
* Issue : https://github.com/harvester/tests/issues/2186

#### What this PR does / why we need it:

Currently in the cypress test suite, we not yet have cluster network and network config related test cases
In order to prepare the ability for cypress to test vlan and multiple vlan network related tests.
We need to add them as the prerequisite requirement for the advanced vm operation testing

#### Test cases

1. Create new cluster network
2. Create new network config under give cluster network


#### Test Result - fixed the following test cases:

Verified works for locally trigger testing on remote test environment

* In headed mode

  <img width="1600" height="734" alt="image" src="https://github.com/user-attachments/assets/138154e3-b34d-4700-b0f8-a7fd6f9be715" />


* In headless mode

  <img width="1586" height="759" alt="image" src="https://github.com/user-attachments/assets/c9664fde-6ee8-4a6e-9ce8-783aadc82d63" />

