### PR TITLE
Add advanced vm migration tests and check further migration information in VM config

### DIFF
--- a/pageobjects/virtualmachine.po.ts
+++ b/pageobjects/virtualmachine.po.ts
@@ -314,6 +314,27 @@ export class VmsPage extends CruResourcePo {
     config.click()
   }
 
+  public openDetailPanel(name: string) {
+    this.goToList();
+    cy.get('.search').type(name);
+
+    const vm = cy.contains('.name-console a', name);
+    expect(vm.should('be.visible'));
+    vm.click();
+  }
+
+  public clickMigrationTab() {
+    cy.get('[data-testid="btn-migration"]').click();
+  }
+
+  public readDetailLabelValue(label: string): Cypress.Chainable<string> {
+    return cy.contains('.label .text-label', label)
+      .parent()
+      .find('.value')
+      .invoke('text')
+      .then((text) => text.trim());
+  }
+
   goToYamlEdit(name: string) {
     this.goToList();
 
@@ -518,7 +539,7 @@ export class VmsPage extends CruResourcePo {
     remoteCommand: string,
     checkResult: boolean = true,
     expectedResult?: string,
-    timeout: number = constants.timeout.maxTimeout
+    timeout: number = constants.timeout.uploadTimeout
   ) {
     // Wait for IP address to be available in the table
     this.censorInColumn(vmName, 3, 'default', 4, '.', 7, {

--- a/testcases/virtualmachines/vm-migration.spec.ts
+++ b/testcases/virtualmachines/vm-migration.spec.ts
@@ -3,6 +3,7 @@ import { VolumePage } from "@/pageobjects/volume.po";
 import NamespacePage from "@/pageobjects/namespace.po";
 import { PageUrl } from "@/constants/constants";
 import { ImagePage } from "@/pageobjects/image.po";
+import VMBackup from '@/pageobjects/vmBackup.po';
 import { generateName } from '@/utils/utils';
 import { Constants } from "@/constants/constants";
 import { host as hostUtil } from '@/utils/utils';
@@ -12,6 +13,7 @@ const volumePO = new VolumePage();
 const constants = new Constants();
 const namespaces = new NamespacePage();
 const imagePO = new ImagePage();
+const vmBackups = new VMBackup();
 
 /**
  * @module testcases/virtualmachines/vm-migration.spec.ts
@@ -31,8 +33,11 @@ describe('VM Live Migration', () => {
    *  - VM should go into migrating status
    * 6. Check can correctly migrate to other node
    * 7. VM migrated should be in running state
-   * 8. ssh to the vm, check the file content is the same
-  */
+   * 8. Click the vm from the virtual machines list
+   * 9. Click the Migration tab
+   * 10. Check the Source Node and Target Node value is the same with previous restored variables
+   * 11. ssh to the vm, check the file content is the same
+  **/
   it('Migrate VM with cloud init data', () => {
     const VM_NAME = generateName('test-vm-migrate');
     const NAMESPACE = 'default'
@@ -113,6 +118,7 @@ sshpwauth: True
         // Perform migration with the found target node
         vms.clickMigrateAction(VM_NAME, `${targetNodeName}`);
 
+        cy.reload();
         // Check VM in migrating state
         vms.censorInColumn(VM_NAME, 3, NAMESPACE, 4, 'Migrating', 2, {
           timeout: constants.timeout.maxTimeout,
@@ -139,6 +145,29 @@ sshpwauth: True
           });
       });
 
+    vms.openDetailPanel(VM_NAME);
+    vms.clickMigrationTab();
+
+    cy.get('@originalNode').then((originalNodeValue) => {
+      const expectedSourceNode = String(originalNodeValue).trim();
+
+      vms.readDetailLabelValue('Source Node').then((sourceNodeValue) => {
+        const detailSourceNode = sourceNodeValue.replace(/\s+/g, ' ').trim();
+        expect(detailSourceNode).to.eq(expectedSourceNode);
+      });
+    });
+
+    cy.get('@targetNode').then((targetNodeValue) => {
+      const expectedTargetNode = String(targetNodeValue).trim();
+
+      vms.readDetailLabelValue('Target Node').then((targetNodeDetailValue) => {
+        const detailTargetNode = targetNodeDetailValue.replace(/\s+/g, ' ').trim();
+        expect(detailTargetNode).to.eq(expectedTargetNode);
+      });
+    });
+
+    vms.goToList();
+
     // Check the file content not changed after migration  
     vms.sshWithCommand(
       VM_NAME,
@@ -150,6 +179,394 @@ sshpwauth: True
     );
     // tear down
     vms.delete(NAMESPACE, VM_NAME)
+
+  });
+
+  /**
+   * 1. Navigate to the VM create page
+   * 2. Create a new VM with cloud init config data
+   * 3. ssh to the vm and create a new file
+   * 4. Create a vm backup named with vm name with `backup-` prefix
+   * 5. Get the original node name before migration
+   * 6. Migrate the VM to another host
+   *  - VM should go into migrating status
+   * 7. Check can correctly migrate to other node
+   * 8. VM migrated should be in running state
+   * 9. Click the vm from the virtual machines list
+   * 10. Click the Migration tab
+   * 11. Check the Source Node and Target Node value is the same with previous restored variables
+   * 12. ssh to the vm, check the file content is the same
+  **/
+  it('Migrate VM with one backup', () => {
+    const VM_NAME = generateName('test-vm-migrate-backup');
+    const NAMESPACE = 'default'
+    const NETWORK = 'vlan1'
+    const largeImageEnv = Cypress.env('largeImage');
+    const BACKUP_NAME = `backup-${VM_NAME}`;
+    const USERDATA = `#cloud-config
+password: password
+chpasswd: { expire: False }
+sshpwauth: True
+`
+
+    const value = {
+      name: VM_NAME,
+      cpu: '1',
+      memory: '2',
+      image: largeImageEnv.name,
+      networks: [{
+        network: NETWORK,
+      }],
+      guestAgent: true,
+      namespace: NAMESPACE,
+      userData: USERDATA,
+    }
+    vms.create(value);
+
+    // Navigate to VM list to ensure we're on the correct page
+    vms.goToList();
+
+    // Check VM is running
+    vms.censorInColumn(VM_NAME, 3, NAMESPACE, 4, 'Running', 2, { timeout: constants.timeout.maxTimeout, nameSelector: '.name-console a' });
+    // Wait for IP address show in table
+    vms.censorInColumn(VM_NAME, 3, NAMESPACE, 4, '.', 7, { timeout: constants.timeout.maxTimeout, nameSelector: '.name-console a' });
+
+    // Check VM display IP address and ssh to the VM to create a test file
+    cy.contains('tr', VM_NAME)
+      .wait(10000) // Wait for system ssh port ready
+      .find('[data-title="IP Address"] > div > span > .copy-to-clipboard-text')
+      .then($els => {
+        const address = $els[0]?.innerText
+
+        vms.sshWithCommand(
+          VM_NAME,
+          'opensuse',
+          'password',
+          'echo "content before migration with backup" > migrate-vm-backup.txt',
+          false  // Don't check the output
+        );
+
+      })
+
+    // Create a VM backup
+    vms.clickVMBackupAction(VM_NAME, BACKUP_NAME);
+
+    // Verify backup is created
+    vmBackups.goToList();
+    vmBackups.censorInColumn(BACKUP_NAME, 3, NAMESPACE, 4, VM_NAME, 5, { timeout: constants.timeout.uploadTimeout, nameSelector: 'a' });
+
+    // Go back to VM list for migration
+    vms.goToList();
+
+    // Get the original node name before migration
+    cy.contains('tr', VM_NAME)
+      .find('td')
+      .eq(7) // Node column
+      .invoke('text')
+      .then((nodeName) => {
+        const originalNode = nodeName.trim();
+        cy.log(`VM is currently running on node: ${originalNode}`);
+
+        // Find the first node that doesn't match the original node
+        const targetNode = hostUtil.list().find(host => {
+          const hostName = host.name || host.customName;
+          return hostName !== originalNode;
+        });
+        const targetNodeName = targetNode?.name || targetNode?.customName || '';
+
+        // Add null check before using targetNodeName
+        if (!targetNodeName) {
+          throw new Error(`No available target node found for migration. Original node: ${originalNode}`);
+        }
+
+        cy.log(`Target node for migration: ${targetNodeName}`);
+
+        // Store both nodes for later comparison
+        cy.wrap(originalNode).as('originalNode');
+        cy.wrap(targetNodeName).as('targetNode');
+
+        // Perform migration with the found target node
+        vms.clickMigrateAction(VM_NAME, `${targetNodeName}`);
+
+        cy.reload();
+        // Check VM in migrating state
+        vms.censorInColumn(VM_NAME, 3, NAMESPACE, 4, 'Migrating', 2, {
+          timeout: constants.timeout.maxTimeout,
+          nameSelector: '.name-console a'
+        });
+
+        // Check VM in running state after migration
+        vms.censorInColumn(VM_NAME, 3, NAMESPACE, 4, 'Running', 2, {
+          timeout: constants.timeout.maxTimeout,
+          nameSelector: '.name-console a'
+        });
+
+        // Verify migration was successful
+        cy.contains('tr', VM_NAME)
+          .find('td')
+          .eq(7)
+          .invoke('text')
+          .then((newNodeName) => {
+            const currentNode = newNodeName.trim();
+            expect(currentNode).to.equal(targetNodeName);
+            expect(currentNode).to.not.equal(originalNode);
+            cy.log(`Migration successful: ${originalNode} → ${currentNode}`);
+
+          });
+      });
+
+    // Open detail panel and verify migration details
+    vms.openDetailPanel(VM_NAME);
+    vms.clickMigrationTab();
+
+    cy.get('@originalNode').then((originalNodeValue) => {
+      const expectedSourceNode = String(originalNodeValue).trim();
+
+      vms.readDetailLabelValue('Source Node').then((sourceNodeValue) => {
+        const detailSourceNode = sourceNodeValue.replace(/\s+/g, ' ').trim();
+        expect(detailSourceNode).to.eq(expectedSourceNode);
+      });
+    });
+
+    cy.get('@targetNode').then((targetNodeValue) => {
+      const expectedTargetNode = String(targetNodeValue).trim();
+
+      vms.readDetailLabelValue('Target Node').then((targetNodeDetailValue) => {
+        const detailTargetNode = targetNodeDetailValue.replace(/\s+/g, ' ').trim();
+        expect(detailTargetNode).to.eq(expectedTargetNode);
+      });
+    });
+
+    vms.goToList();
+
+    // Check the file content not changed after migration  
+    vms.sshWithCommand(
+      VM_NAME,
+      'opensuse',
+      'password',
+      'cat migrate-vm-backup.txt',
+      true,  // Check the output
+      'content before migration with backup'
+    );
+
+    // Cleanup - delete backup first, then VM
+    vmBackups.deleteFromStore(`${NAMESPACE}/${BACKUP_NAME}`);
+    vms.delete(NAMESPACE, VM_NAME)
+
+  });
+
+  /**
+   * 1. Navigate to the VM create page
+   * 2. Create a new volume with size 5 and named 'migration-vol' with generateName function
+   * 3. Create a new VM with cloud init config data
+   * 4. Attach the new volume to the new vm using hot-plug
+   * 5. ssh to the vm and set mount point '/data' on the added volume /dev/sda
+   * 6. Create a file on the root disk
+   * 7. Create a file on the second disk /dev/sda mounted at /data
+   * 8. Get the original node name before migration
+   * 9. Migrate the VM to another host
+   *  - VM should go into migrating status
+   * 10. Check can correctly migrate to other node
+   * 11. VM migrated should be in running state
+   * 12. Click the vm from the virtual machines list
+   * 13. Click the Migration tab
+   * 14. Check the Source Node and Target Node value is the same with previous restored variables
+   * 15. ssh to the vm, check the content is the same in file root-disk.txt
+   * 16. Check the content is the same in file data-disk.txt at /data/data-disk.txt
+  **/
+  it('Migrate VM has multiple volumes', () => {
+    const VM_NAME = generateName('test-vm-migrate-volumes');
+    const NAMESPACE = 'default'
+    const NETWORK = 'vlan1'
+    const VOLUME_NAME = generateName('migration-vol');
+    const largeImageEnv = Cypress.env('largeImage');
+    const USERDATA = `#cloud-config
+password: password
+chpasswd: { expire: False }
+sshpwauth: True
+`
+
+    // Create a new volume
+    volumePO.goToCreate();
+    volumePO.setNameNsDescription(VOLUME_NAME, NAMESPACE);
+    volumePO.setBasics({ size: '5' });
+    volumePO.save();
+    volumePO.censorInColumn(VOLUME_NAME, 3, NAMESPACE, 4, 'Ready', 2);
+
+    // Create VM with cloud init config
+    const value = {
+      name: VM_NAME,
+      cpu: '1',
+      memory: '2',
+      image: largeImageEnv.name,
+      networks: [{
+        network: NETWORK,
+      }],
+      guestAgent: true,
+      namespace: NAMESPACE,
+      userData: USERDATA,
+    }
+    vms.create(value);
+
+    // Navigate to VM list to ensure we're on the correct page
+    vms.goToList();
+
+    // Check VM is running
+    vms.censorInColumn(VM_NAME, 3, NAMESPACE, 4, 'Running', 2, { timeout: constants.timeout.maxTimeout, nameSelector: '.name-console a' });
+    // Wait for IP address show in table  
+    vms.censorInColumn(VM_NAME, 3, NAMESPACE, 4, '.', 7, { timeout: constants.timeout.uploadTimeout, nameSelector: '.name-console a' });
+
+    // Hot plug the additional volume
+    vms.plugVolume(VM_NAME, [VOLUME_NAME], NAMESPACE);
+
+    // SSH to VM and setup mount point and create files
+    cy.contains('tr', VM_NAME)
+      .wait(10000) // Wait for system ssh port ready
+      .find('[data-title="IP Address"] > div > span > .copy-to-clipboard-text', { 
+        timeout: constants.timeout.uploadTimeout 
+      })
+      .then($els => {
+        const address = $els[0]?.innerText;
+
+        // Mount the second disk to /data
+        vms.sshWithCommand(
+          VM_NAME,
+          'opensuse',
+          'password',
+          'sudo mkfs.ext4 -F /dev/sda && sudo mkdir -p /data && sudo mount /dev/sda /data && UUID=$(sudo blkid -s UUID -o value /dev/sda) && echo "UUID=$UUID /data ext4 defaults 0 0" | sudo tee -a /etc/fstab && sudo mount -a',
+          false  // Don't check the output
+        );
+
+        // Create file on root disk
+        vms.sshWithCommand(
+          VM_NAME,
+          'opensuse',
+          'password',
+          'echo "before migration on root disk" > root-disk.txt',
+          false  // Don't check the output
+        );
+
+        // Create file on data disk
+        vms.sshWithCommand(
+          VM_NAME,
+          'opensuse',
+          'password',
+          'sudo sh -c "echo \\\"before migration on data disk\\\" > /data/data-disk.txt"',
+          false  // Don't check the output
+        );
+      });
+
+    // Go back to VM list for migration
+    vms.goToList();
+
+    // Get the original node name before migration
+    cy.contains('tr', VM_NAME)
+      .find('td')
+      .eq(7) // Node column
+      .invoke('text')
+      .then((nodeName) => {
+        const originalNode = nodeName.trim();
+        cy.log(`VM is currently running on node: ${originalNode}`);
+
+        // Find the first node that doesn't match the original node
+        const targetNode = hostUtil.list().find(host => {
+          const hostName = host.name || host.customName;
+          return hostName !== originalNode;
+        });
+        const targetNodeName = targetNode?.name || targetNode?.customName || '';
+
+        // Add null check before using targetNodeName
+        if (!targetNodeName) {
+          throw new Error(`No available target node found for migration. Original node: ${originalNode}`);
+        }
+
+        cy.log(`Target node for migration: ${targetNodeName}`);
+
+        // Store both nodes for later comparison
+        cy.wrap(originalNode).as('originalNode');
+        cy.wrap(targetNodeName).as('targetNode');
+
+        // Perform migration with the found target node
+        vms.clickMigrateAction(VM_NAME, `${targetNodeName}`);
+
+        cy.reload();
+        // Check VM in migrating state
+        vms.censorInColumn(VM_NAME, 3, NAMESPACE, 4, 'Migrating', 2, {
+          timeout: constants.timeout.maxTimeout,
+          nameSelector: '.name-console a'
+        });
+
+        // Check VM in running state after migration
+        vms.censorInColumn(VM_NAME, 3, NAMESPACE, 4, 'Running', 2, {
+          timeout: constants.timeout.uploadTimeout,
+          nameSelector: '.name-console a'
+        });
+
+        // Reload page to ensure migration details are updated
+        cy.wait(10000);
+
+        // Verify migration was successful
+        cy.contains('tr', VM_NAME)
+          .find('td')
+          .eq(7)
+          .invoke('text')
+          .then((newNodeName) => {
+            const currentNode = newNodeName.trim();
+            expect(currentNode).to.equal(targetNodeName);
+            expect(currentNode).to.not.equal(originalNode);
+            cy.log(`Migration successful: ${originalNode} → ${currentNode}`);
+          });
+      });
+
+    // Open detail panel and verify migration details
+    vms.openDetailPanel(VM_NAME);
+    vms.clickMigrationTab();
+    // Wait for migration details to load
+    cy.wait(5000); 
+
+    cy.get('@originalNode').then((originalNodeValue) => {
+      const expectedSourceNode = String(originalNodeValue).trim();
+
+      vms.readDetailLabelValue('Source Node').then((sourceNodeValue) => {
+        const detailSourceNode = sourceNodeValue.replace(/\s+/g, ' ').trim();
+        expect(detailSourceNode).to.eq(expectedSourceNode);
+      });
+    });
+
+    cy.get('@targetNode').then((targetNodeValue) => {
+      const expectedTargetNode = String(targetNodeValue).trim();
+
+      vms.readDetailLabelValue('Target Node').then((targetNodeDetailValue) => {
+        const detailTargetNode = targetNodeDetailValue.replace(/\s+/g, ' ').trim();
+        expect(detailTargetNode).to.eq(expectedTargetNode);
+      });
+    });
+
+    vms.goToList();
+
+    // Check the file content not changed after migration on root disk
+    vms.sshWithCommand(
+      VM_NAME,
+      'opensuse',
+      'password',
+      'cat root-disk.txt',
+      true,  // Check the output
+      'before migration on root disk'
+    );
+
+    // Check the file content not changed after migration on data disk
+    vms.sshWithCommand(
+      VM_NAME,
+      'opensuse',
+      'password',
+      'cat /data/data-disk.txt',
+      true,  // Check the output
+      'before migration on data disk'
+    );
+
+    // Cleanup - delete VM and volume
+    vms.delete(NAMESPACE, VM_NAME);
+    volumePO.delete(NAMESPACE, VOLUME_NAME);
 
   });
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
* Issue : https://github.com/harvester/tests/issues/1547

#### What this PR does / why we need it:

Follow the original development plan in https://github.com/harvester/tests/issues/1547

We already have the first basic vm migration test in https://github.com/harvester/harvester-ui-tests/pull/35

Then we need enhance the existing one to also check the migration details tab information inside VM configuration.

And add the remaining advanced vm migration tests 


### Changes

1. Fix the flaky test result in test `Migrate VM with cloud init data`
2. Add further check the original and target node information inside VM migration tab (From v1.6.0) 
3. Add new tests: **Migrate VM with one backup** and **Migrate a VM that has multiple volumes**

### Step by step test plan
* https://github.com/harvester/tests/issues/1547#issuecomment-2901690377


#### Test Result - fixed the following test cases:
1. Verified `PASS` in local test run to remote environment in **headed** mode

  <img width="1600" height="734" alt="image" src="https://github.com/user-attachments/assets/a5d073b5-04f0-447b-a839-c2dde01d2c3d" />

2. Verified `PASS` in local test run to remote environment in **headless** mode

  <img width="1586" height="759" alt="image" src="https://github.com/user-attachments/assets/186575b4-ea4d-4636-abc3-d4338e1007f7" />



