### PR TITLE
Fix input cluster-registration-url with tls and align with main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get install -y git
 ADD https://dl.min.io/client/mc/release/linux-amd64/mc /usr/local/bin/mc
 RUN chmod +x /usr/local/bin/mc
 
-RUN git clone https://github.com/harvester/harvester-ui-tests.git
+# Please specify your desired harvester-ui-tests repository and branch here
+# RUN git clone https://github.com/harvester/harvester-ui-tests.git
 
 WORKDIR /harvester-ui-tests
 

--- a/pageobjects/rancher.po.ts
+++ b/pageobjects/rancher.po.ts
@@ -322,11 +322,20 @@ export class rancherPage {
             cy.get('#cluster-registration-url').click();
             cy.get('.icon.icon.icon-edit').click();
 
-            cy.get('input').clear().type(url);
+            cy.get('.labeled-input input[role="textbox"]').clear({ force: true }).type(url);
+            cy.contains('.checkbox-outer-container', 'Insecure Skip TLS Verify')
+              .then(($container) => {
+                const $checkbox = $container.find('input[type="checkbox"]');
 
+                if (!$checkbox.is(':checked')) {
+                  cy.wrap($container).find('.checkbox-custom').click();
+                }
+              });
         })
 
         cy.get('.cru-resource-footer > div > .btn').should('contain', 'Save').click();
+        // Handle the Tip confirmation dialog that appears after saving
+        cy.get('[data-testid="card-actions-slot"]').contains('button', 'OK').click();
     }
 
     // public checkState(value: ValueInterface, valid: boolean = true) {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
* Issue : 
  - https://github.com/harvester/tests/issues/2638
  - https://github.com/harvester/tests/issues/2639

#### What this PR does / why we need it:

According to the test report in: 
* http://10.115.1.7/job/harvester-cypress-test/100/HTML_20Report/

The are three failed tests: 

1. Harvester import Rancher
2. Check Harvester Cluster Status
3. Check Rancher Harvester dashboard

The reason is in v1.7.2-rc1 they introduced the TLS verify option

  <img width="1351" height="497" alt="Image" src="https://github.com/user-attachments/assets/a3a1a7b3-b76e-408f-a790-423a35e27ca5" />

We need to update the test script on `release-v1.7` branch too.

And we also need to address the issue explained in issue https://github.com/harvester/tests/issues/2639

When we execute cypress test on release branch release-v1.7 to test previous version (e.g v1.7.2)

It would always clone the harvester-ui-tests from the main branch.
Follow by copying the release branch clone on the host path to the docker container.

This will cause the content overlapping and duplicate problem.

#### Test Result - fixed the following test cases:

Tested can pass all the Rancher integration tests on v1.7.2-rc1

* http://10.115.1.7/job/harvester-cypress-test/101/HTML_20Report/