### PR TITLE
Comment out the cloned test step in Dockerfile to avoid overlapping test cases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN echo "${MC_SUM}  /usr/local/bin/mc" | sha256sum -c - && \
     chown root:root /usr/local/bin/mc && \
     chmod 0755 /usr/local/bin/mc
 
-RUN git clone https://github.com/harvester/harvester-ui-tests.git
+# Please specify your desired harvester-ui-tests repository and branch here
+# RUN git clone https://github.com/harvester/harvester-ui-tests.git
 
 WORKDIR /harvester-ui-tests
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
* Issue : 
  - https://github.com/harvester/tests/issues/2639

#### What this PR does / why we need it:


We need to address the issue explained in issue https://github.com/harvester/tests/issues/2639 on the harvester-ui-tests/main too.

When we execute cypress test on release branch release-v1.7 to test previous version (e.g v1.7.2)

It would always clone the harvester-ui-tests from the main branch.
Follow by copying the release branch clone on the host path to the docker container.

This will cause the content overlapping and duplicate problem.

Instead fixing this on the `release-v1.7` branch, we also need to update this to the main.

#### Test Result - fixed the following test cases:

Tested can pass all the Rancher integration tests on v1.8.0

* http://10.115.1.7/job/harvester-cypress-test/104/HTML_20Report/

  <img width="1594" height="790" alt="image" src="https://github.com/user-attachments/assets/b4b21b77-fabe-4173-92d7-818863bf8579" />

