### PR TITLE
Add node number compute

### DIFF
--- a/models/host.ts
+++ b/models/host.ts
@@ -1,4 +1,6 @@
 export interface Node {
   name: string;
   customName: string;
+  disks?: { name: string; devPath: string }[];
+  witnessNode?: boolean;
 }

--- a/testcases/dashboard/hosts.spec.ts
+++ b/testcases/dashboard/hosts.spec.ts
@@ -1,9 +1,31 @@
 import { HostsPage } from "@/pageobjects/hosts.po";
 import { EditYamlPage } from "@/pageobjects/editYaml.po";
 import { HCI } from '@/constants/types'
+import { Node } from '@/models/host';
 
 const hosts = new HostsPage();
 const editYaml = new EditYamlPage();
+
+let hostNodes: Node[] = [];
+
+before(() => {
+  // Authenticate via the UI (sets the R_SESS session cookie), then query the API
+  cy.login();
+  cy.request({
+    method: 'GET',
+    url: '/v1/harvester/nodes',
+    headers: { Accept: 'application/json' },
+  }).then((resp: Cypress.Response<any>) => {
+    const nodeList: any[] = resp.body?.data ?? resp.body?.items ?? [];
+    expect(nodeList.length, 'Cluster must have at least one node').to.be.greaterThan(0);
+    hostNodes = nodeList.map((node) => ({
+      name: (node.id ?? node.metadata?.name) as string,
+      customName: '',
+      disks: [{ name: '/dev/vda', devPath: '/dev/vda' }],
+      witnessNode: false,
+    }));
+  });
+});
 
 /**
  * 1. Login
@@ -16,7 +38,7 @@ const editYaml = new EditYamlPage();
 */
 describe('should insert custom name into YAML', () => {
   it('should insert custom name into YAML', () => {
-    const host = Cypress.env('host')[0];
+    const host = hostNodes[0];
     const hostName = host.name
     const customName = 'test-custom-name-yaml';
 
@@ -52,7 +74,7 @@ describe('Check edit host', () => {
   it('Check edit host', () => {
     cy.login();
 
-    const host = Cypress.env('host')[0];
+    const host = hostNodes[0];
     const hostName = host.name
     const customName = 'test-custom-name';
     const consoleUrl = 'https://test-console-url';
@@ -73,8 +95,8 @@ describe('Check Add disk', () => {
   it.skip('Check Add disk', () => {
     cy.login();
     
-    const host = Cypress.env('host')[0];
-    const disk = host.disks[0]
+    const host = hostNodes[0];
+    const disk = host.disks![0]
     
     cy.visit(`/harvester/c/local/${HCI.HOST}/${host.name}?mode=edit`)
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
* Issue : 

#### What this PR does / why we need it: 
Node number and names are computed dynamically in the tests now.
Node number and names are removed from Jenkins parameter. They should be computed dynamically not hardcoded in CI.


#### Test Result - fixed the following test cases:

<img width="1662" height="895" alt="Screenshot 2026-06-08 at 12 07 46 PM" src="https://github.com/user-attachments/assets/50aba996-241c-48c2-9883-1f900fbfedf4" />
