### PR TITLE
Fix cypress tests

### DIFF
--- a/constants/constants.ts
+++ b/constants/constants.ts
@@ -1,5 +1,5 @@
 export class Constants {
-    public timeout = { timeout: 10000, maxTimeout: 60000, uploadTimeout: 600000, downloadTimeout: 600000, provisionTimeout: 1500000 };
+    public timeout = { timeout: 10000, maxTimeout: 180000, uploadTimeout: 600000, downloadTimeout: 600000, provisionTimeout: 1500000 };
     public username = Cypress.env("username");
     public password = Cypress.env("password");
     public mockPassword = Cypress.env("mockPassword");

--- a/cypress.env.json.example
+++ b/cypress.env.json.example
@@ -9,21 +9,8 @@
   "rancherPassword": "admin",
   "rancherBootstrapPassword": "admin",
   "harvester_ui_extension_repo_url": "https://github.com/harvester/harvester-ui-extension",
-  "harvester_ui_extension_branch": "v1.0-head",
-  "harvester_ui_extension_version": "1.0.6-rc1",
-  "host": [
-    {
-      "name": "",
-      "customName": "",
-      "disks": [
-        {
-          "name": "",
-          "devPath": ""
-        }
-      ],
-      "witnessNode": false
-    }
-  ],
+  "harvester_ui_extension_branch": "v1.8-head",
+  "harvester_ui_extension_version": "1.8.0",
   "largeImage": {
     "name": "openSUSE-Leap-15.3-3-DVD-x86_64-Build38.1-Media.iso",
     "url": "https://mirrors.bfsu.edu.cn/opensuse/distribution/leap/15.3/iso/openSUSE-Leap-15.3-3-DVD-x86_64-Build38.1-Media.iso"
@@ -32,16 +19,20 @@
     "name": "cirros-0.5.2-aarch64-disk.img",
     "url": "https://github.com/cirros-dev/cirros/releases/download/0.5.2/cirros-0.5.2-aarch64-disk.img"
   },
-  "vlans": [
-    {
-      "nic": "ens7",
-      "vlan": 100
-    },
-    {
-      "nic": "ens8",
-      "vlan": 104
-    }
-  ],
+  "nfsEndPoint": "",
+  "backupTarget": {
+    "endpoint": "",
+    "bucketName": "",
+    "bucketRegion": "",
+    "accessKey": "",
+    "secretKey": ""
+  },
+  "networks": {
+    "nic": "mgmt",
+    "cidr": "190.0.0.0/21",
+    "gateway": "190.0.0.10",
+    "vlans": [1, 2]
+  },
   "sshKey": "ssh-rsa GgVY6KnKpJqrBd/BGuUoHhh/C3CXhDojb1G1Td6hktaUwH+Q== username@email.com",
   "privateKeyPath": "/Users/username/.ssh/id_rsa"
 }

--- a/pageobjects/clusterNetwork.po.ts
+++ b/pageobjects/clusterNetwork.po.ts
@@ -81,11 +81,12 @@ export default class clusterNetworkPage extends CruResource {
     }
 
     /**
-     * Select a NIC from the dropdown
-     * @param nicName - the NIC name to select (e.g., "ens6 (Up)")
+     * Select a NIC from the dropdown by partial name match.
+     * @param nicName - the NIC name or partial name to select (e.g., "eno6")
      */
     public selectNIC(nicName: string) {
-        this.NICs().select({ option: nicName });
+        this.NICs().self().click();
+        cy.get('.vs__dropdown-menu li').contains(nicName).click();
     }
 
     /**

--- a/pageobjects/rancher.po.ts
+++ b/pageobjects/rancher.po.ts
@@ -56,7 +56,7 @@ export class rancherPage {
     private local_apps_repo_branch = '[data-testid="clusterrepo-git-branch-input"]';
     private local_apps_repo_create = '[data-testid="action-button-async-button"]';
 
-    private extension_card_harvester = '[data-testid="extension-card-harvester"]';
+    private extension_card_harvester = '[data-testid="item-card-cluster/harvester/harvester"]';
     private extension_card_menu_button = '[data-testid="item-card-header-action-menu"]';
     private extension_dropdown_menu_install = 'div[dropdown-menu-item]';
     private extension_card_harvester_install = '[data-testid="extension-card-install-btn-harvester"]';
@@ -65,8 +65,7 @@ export class rancherPage {
 
     private extension_installed_tab = '[data-testid="installed"]';
     private extension_available_tab = '[data-testid="available"]';
-    private extension_installed_card_harvester = '[data-testid="extension-card-harvester"]';
-    private extension_installed_card_harvester_213 = '[data-testid="item-card-cluster/harvester/harvester"]';
+    private extension_installed_card_harvester = '[data-testid="item-card-cluster/harvester/harvester"]';
     private extension_card_harvester_uninstall = '[data-testid="extension-card-uninstall-btn-harvester"]';
 
     private cloudCredential_page_createButton = '.actions > .btn';
@@ -264,44 +263,96 @@ export class rancherPage {
     }
 
     public install_harvester_ui_extension(version: string, rancherVersion: string) {
-        // Visit the Extension -> Available page
-        this.visit_available_extensions();
-
         // Parse minor version to determine which UI flow to use (v2.13+ uses dropdown menu)
         const minorVersion = parseInt(rancherVersion.replace(/^v/, '').split('.')[1], 10);
         const isNewUI = minorVersion >= 13;
 
-        // Check Rancher version to determine which UI flow to use
-        if (isNewUI) {
-            // Rancher v2.13+ uses dropdown menu for install
-            cy.log(`Using Rancher v2.13+ UI flow (detected: ${rancherVersion})`);
-            // Click the 3-dot menu button on the Harvester extension card
-            cy.get(this.extension_card_menu_button).click();
-            // Click the Install option from the dropdown menu
-            cy.get(this.extension_dropdown_menu_install).contains('Install').click();
-        } else {
-            // Rancher < v2.13 uses direct install button
-            cy.log(`Using Rancher < v2.13 UI flow (detected: ${rancherVersion})`);
-            cy.get(this.extension_card_harvester_install).click();
-        }
+        // Navigate to the main extensions page
+        cy.visit('/c/_/uiplugins');
 
-        // Common steps for both versions
-        // Search and select the version from the dropdown menu list
-        const versionSelect = new LabeledSelectPo('[data-testid="install-ext-modal-select-version"]');
-        versionSelect.select({ option: version, selector: '.vs__dropdown-menu' });
-        // Click the Install button to install the Harvester extension
-        cy.get(this.install_harvester_extensionButton).click();
-        cy.get(this.extension_reloadButton).click();
+        cy.get('[data-testid="btn-installed"]', { timeout: 15000 }).click();
 
-        if (isNewUI) {
-            // Switch to Installed tab
-            cy.get(this.extension_installed_tab).click();
-            // Ensure the Harvester extension card exists
-            cy.get(this.extension_installed_card_harvester_213).should('exist', { timeout: constants.timeout.timeout });
-        } else {
-            // Ensure the Harvester extension card exists
-            cy.get(this.extension_installed_card_harvester).should('exist', { timeout: constants.timeout.timeout });
-        }
+        // Give the installed list time to render before we check for the card
+        cy.get('body').then($body => {
+            const alreadyInstalled = $body.find(this.extension_installed_card_harvester).length > 0;
+
+            if (alreadyInstalled) {
+                // Read the installed version from the first sub-header badge on the card
+                cy.get(this.extension_installed_card_harvester)
+                    .find('[data-testid="app-chart-card-sub-header-item"]')
+                    .first()
+                    .invoke('text')
+                    .then(installedVersion => {
+                        if (installedVersion.trim() === version) {
+                            cy.log(`Harvester extension version ${version} already installed, nothing to do`);
+                        } else {
+                            // Wrong version installed – trigger an upgrade or downgrade via the action menu
+                            cy.log(`Version mismatch: installed="${installedVersion.trim()}", expected="${version}" – updating`);
+                            cy.get(this.extension_installed_card_harvester)
+                                .find(this.extension_card_menu_button)
+                                .click();
+                            // Click whichever of "Update" / "Downgrade" is present; both share the same attribute
+                            cy.get(this.extension_dropdown_menu_install)
+                                .filter((_, el) => {
+                                    const t = el.textContent?.trim() ?? '';
+                                    return t === 'Update' || t === 'Downgrade';
+                                })
+                                .first()
+                                .click();
+
+                            // Select exact version in the update dialog and confirm
+                            const versionSelect = new LabeledSelectPo('[data-testid="install-ext-modal-select-version"]');
+                            versionSelect.select({ option: version, selector: '.vs__dropdown-menu' });
+                            cy.get(this.install_harvester_extensionButton).click();
+                            cy.get(this.extension_reloadButton, { timeout: constants.timeout.uploadTimeout }).click();
+
+                            // Verify after reload
+                            cy.get('[data-testid="btn-installed"]').click();
+                            cy.get(this.extension_installed_card_harvester)
+                                .should('exist', { timeout: constants.timeout.timeout });
+                        }
+                    });
+            } else {
+                // Not yet installed – go to Available tab and install
+                cy.log(`Installing Harvester extension version ${version} (Rancher: ${rancherVersion})`);
+                cy.get('[data-testid="btn-available"]').click();
+
+                if (isNewUI) {
+                    // Rancher v2.13+ uses dropdown action-menu for install
+                    cy.log(`Using Rancher v2.13+ UI flow (detected: ${rancherVersion})`);
+                    cy.get(this.extension_card_harvester, { timeout: constants.timeout.uploadTimeout })
+                        .should('be.visible')
+                        .find(this.extension_card_menu_button)
+                        .click();
+                    // The dropdown item has attribute dropdown-menu-item=""; use exact text match
+                    cy.get(this.extension_dropdown_menu_install)
+                        .filter((_, el) => el.textContent?.trim() === 'Install')
+                        .first()
+                        .click();
+                } else {
+                    // Rancher < v2.13 uses a direct install button on the card
+                    cy.log(`Using Rancher < v2.13 UI flow (detected: ${rancherVersion})`);
+                    cy.get(this.extension_card_harvester_install, { timeout: constants.timeout.uploadTimeout })
+                        .should('be.visible')
+                        .click();
+                }
+
+                // Select the desired version from the install dialog dropdown
+                const versionSelect = new LabeledSelectPo('[data-testid="install-ext-modal-select-version"]');
+                versionSelect.select({ option: version, selector: '.vs__dropdown-menu' });
+
+                // Confirm the installation
+                cy.get(this.install_harvester_extensionButton).click();
+
+                // Wait for Rancher to finish deploying the extension (Helm chart) and show reload banner
+                cy.get(this.extension_reloadButton, { timeout: constants.timeout.uploadTimeout }).click();
+
+                // After reload, switch to Installed tab and confirm the card is present
+                cy.get('[data-testid="btn-installed"]').click();
+                cy.get(this.extension_installed_card_harvester)
+                    .should('exist', { timeout: constants.timeout.timeout });
+            }
+        });
     }
 
     public importHarvester() {

--- a/pageobjects/settings.po.ts
+++ b/pageobjects/settings.po.ts
@@ -87,6 +87,12 @@ export default class SettingsPagePo extends CruResource {
       cpu.input(value.cpu)
     }
 
+    clearBackupTarget() {
+        this.goToList();
+        this.clickMenu('backup-target', 'Edit Setting', 'backup-target');
+        this.clickUseDefaultButton();
+    }
+
     setNFSBackupTarget(type: string, endpoint: string) {
         const select = new LabeledSelectPo("section .labeled-select.hoverable", `:contains("Type")`);
         select.select({option: type, selector: '.vs__dropdown-menu'});

--- a/pageobjects/virtualmachine.po.ts
+++ b/pageobjects/virtualmachine.po.ts
@@ -461,11 +461,11 @@ export class VmsPage extends CruResourcePo {
     cy.get('.dropdownTarget').contains('Edit Config').click()
   }
 
-  public edit(name: string, value: ValueInterface) {
+  public edit(name: string, value: ValueInterface, namespace: string = 'default') {
     this.init()
     this.goToEdit(name);
     this.setValue(value);
-    this.save({ edit: true });
+    this.update(`${namespace}/${name}`);
   }
 
   public delete(namespace: string, name: string, displayName?: string, { removeRootDisk, id }: { removeRootDisk?: boolean, id?: string } = { removeRootDisk: true }) {

--- a/support/commands.js
+++ b/support/commands.js
@@ -11,32 +11,33 @@ require('cy-verify-downloads').addCustomCommand();
 
 Cypress.Commands.add('login', (params = {}) => {
     let url = params.url || constants.dashboardUrl;
-    const username = params.username ||   Cypress.env('username');
+    const username = params.username || Cypress.env('username');
     const password = params.password || Cypress.env('password');
-
-    const isDev = Cypress.env('NODE_ENV') === 'dev';
-    const baseUrl = isDev ? Cypress.config('baseUrl') : `${Cypress.config('baseUrl')}/dashboard`;
-    cy.intercept('GET', '/v1-public/authproviders*').as('authProviders');
-    cy.visit(`/auth/login`);
-    cy.wait('@authProviders').then(res => {
-      const { CSRF } = cookie.parse(document.cookie);
-      cy.request({
-        method: 'POST',
-        url: '/v3-public/localProviders/local?action=login',
-        body: {
-          description:"UI session",
-          responseType:"cookie",
-          username,
-          password
-        },
-        headers: {
-          'x-api-csrf': CSRF
-        }
-      }).then(() => {
-        cy.visit(url).log(url); // After successful login, you can switch to the specified page, which is the home page by default
-        cy.get(".dashboard-content .product-name", { timeout: constants.timeout.maxTimeout }).contains("Harvester")
+    
+    cy.session(username, () => {
+      cy.intercept('GET', '/v1-public/authproviders*').as('authProviders');
+      cy.visit(`/auth/login`);
+      cy.wait('@authProviders').then(res => {
+        const { CSRF } = cookie.parse(document.cookie);
+        cy.request({
+          method: 'POST',
+          url: '/v3-public/localProviders/local?action=login',
+          body: {
+            description: "UI session",
+            responseType: "cookie",
+            username,
+            password
+          },
+          headers: {
+            'x-api-csrf': CSRF
+          }
+        });
       });
-    })
+    });
+
+    // Navigate to the target url after session is established/restored
+    cy.visit(url);
+    cy.get(".dashboard-content .product-name", { timeout: constants.timeout.maxTimeout }).contains("Harvester");
 });
 
 Cypress.Commands.add('stopOnFailed', () => {

--- a/testcases/backupAndSnapshot/vmBackup.spec.ts
+++ b/testcases/backupAndSnapshot/vmBackup.spec.ts
@@ -2,23 +2,59 @@ import { onlyOn } from "@cypress/skip-test";
 import { VmsPage } from "@/pageobjects/virtualmachine.po";
 import VMBackup from '@/pageobjects/vmBackup.po';
 import { PageUrl } from "@/constants/constants";
+import SettingsPagePo from "@/pageobjects/settings.po";
+import { generateName } from "@/utils/utils";
 
 const vms = new VmsPage();
 const vmBackups = new VMBackup();
+const settings = new SettingsPagePo();
 
 describe('VM Backup Validation', () => {
-  const vmName = 'test';
-  let createVMBackupSuccess: boolean = false ;
-  const vmBackupName = 'test-vm-backup';
+  // Unique names generated once per suite run — shared across all it() blocks
+  const vmName = generateName('test-vm');
+  const vmBackupName = generateName('test-vm-backup');
+  const namespace = 'default';
+
+  let createVMBackupSuccess: boolean = false;
+  let backupTargetSetByTest: boolean = false;
+
+  before(() => {
+    // Ensure backup target is configured before running any backup tests
+    cy.login({ url: PageUrl.setting });
+    cy.request({
+      method: 'GET',
+      url: '/v1/harvester/harvesterhci.io.settings/backup-target',
+    }).then((res) => {
+      let parsed: any = {};
+      try { parsed = JSON.parse(res.body?.value); } catch (e) {}
+
+      if (!parsed?.endpoint) {
+        cy.log('Backup target not configured — setting NFS backup target');
+        settings.clickMenu('backup-target', 'Edit Setting', 'backup-target');
+        settings.setNFSBackupTarget('NFS', Cypress.env('nfsEndPoint'));
+        settings.update('backup-target');
+        backupTargetSetByTest = true;
+      } else {
+        cy.log(`Backup target already configured: ${parsed.type || 'unknown type'}`);
+      }
+    });
+  });
+
+  after(() => {
+    // Only clear the backup target if this test suite was the one that set it
+    if (backupTargetSetByTest) {
+      cy.log('Clearing backup target set by this test suite');
+      cy.login({ url: PageUrl.setting });
+      settings.clearBackupTarget();
+    }
+  });
 
   beforeEach(() => {
     cy.login({url: PageUrl.virtualMachine});
+    vms.init();
   });
 
   it('Take a vm backup from vm', () => {
-    // Create a vm to test the backup operation
-    const namespace = 'default';
-
     const id = `${namespace}/${vmName}`;
     const imageEnv = Cypress.env('image');
     const volume = [{
@@ -28,8 +64,8 @@ describe('VM Backup Validation', () => {
       image: `default/${Cypress._.toLower(imageEnv.name)}`,
     }];
 
-    vmBackups.deleteFromStore(`${namespace}/${vmBackupName}`)
-    vms.deleteVMFromStore(id)
+    vmBackups.deleteFromStore(`${namespace}/${vmBackupName}`);
+    vms.deleteVMFromStore(id);
     vms.goToCreate();
     vms.deleteVMFromStore(`${namespace}/${vmName}`);
     vms.setNameNsDescription(vmName, namespace);
@@ -37,64 +73,63 @@ describe('VM Backup Validation', () => {
     vms.setVolumes(volume);
     vms.save();
 
-    // create a vm snapshot
+    // Wait for VM to be running, then take backup
     vms.checkVMState(vmName, 'Running');
     vms.clickVMBackupAction(vmName, vmBackupName);
 
-    // check vm snapshot
+    // Verify backup appears in the backup list filtered by its unique name
     vmBackups.goToList();
-    // vmBackups.checkState(vmBackupName, vmName);
     vmBackups.censorInColumn(vmBackupName, 3, namespace, 4, vmName, 5, { timeout: 5000, nameSelector: 'a' });
 
-    createVMBackupSuccess = true
+    createVMBackupSuccess = true;
   })
 
   it('Restore new VM from vm backup', () => {
     onlyOn(createVMBackupSuccess);
-    
-    const newVMName = 'create-new-from-backup';
 
-    vms.deleteVMFromStore(`default/${newVMName}`)
+    const newVMName = generateName('restore-new');
+
+    vms.deleteVMFromStore(`${namespace}/${newVMName}`);
     vmBackups.goToList();
     vmBackups.restoreNew(vmBackupName, newVMName);
     vms.checkVMState(newVMName);
 
     // delete vm
-    vms.deleteVMFromStore(`default/${newVMName}`);
+    vms.deleteVMFromStore(`${namespace}/${newVMName}`);
   })
 
   it('Restore New VM in another namespace from vm backup', () => {
     onlyOn(createVMBackupSuccess);
-    
-    const newVMName = 'create-new-from-backup';
 
-    vms.deleteVMFromStore(`default/${newVMName}`)
+    const newVMName = generateName('restore-new-ns');
+
+    vms.deleteVMFromStore(`${namespace}/${newVMName}`);
     vmBackups.goToList();
     vmBackups.restoreNew(vmBackupName, newVMName, 'harvester-public');
     vms.checkVMState(newVMName);
 
     // delete vm
-    vms.deleteVMFromStore(`default/${newVMName}`);
+    vms.deleteVMFromStore(`${namespace}/${newVMName}`);
   })
 
   it('Restore Existing VM from vm backup', () => {
     onlyOn(createVMBackupSuccess);
-    
+
     vms.goToList();
     vms.clickAction(vmName, 'Stop');
-    vms.checkVMState(vmName, 'Off')
+    vms.checkVMState(vmName, 'Off');
     vmBackups.goToList();
     vmBackups.restoreExistingVM(vmBackupName);
     vms.checkVMState(vmName);
 
     // delete vm
-    vms.deleteVMFromStore(`default/test`);
+    vms.deleteVMFromStore(`${namespace}/${vmName}`);
   })
 
   it('Delete backup', () => {
     onlyOn(createVMBackupSuccess);
-    
+
     vmBackups.goToList();
-    vmBackups.deleteFromStore(`default/${vmBackupName}`);
+    vmBackups.deleteFromStore(`${namespace}/${vmBackupName}`);
   })
 })

--- a/testcases/image/images.spec.ts
+++ b/testcases/image/images.spec.ts
@@ -40,7 +40,7 @@ describe('Auto setup image from cypress environment', () => {
                 image.setNameNsDescription(IMAGE_NAME, namespace);
                 image.setBasics({ url: IMAGE_URL });
                 image.save();
-                image.checkState({ name: IMAGE_NAME });
+                image.checkState_without_size({ name: IMAGE_NAME });
             }
         })
     })
@@ -64,7 +64,7 @@ describe('Create an image with valid image URL', () => {
     const largeImageEnv = Cypress.env('largeImage');
     const IMAGE_NAME = generateName('auto-image-valid-url-test');
     const IMAGE_URL = imageEnv.url;
-    const LARGE_IMAGE_NAME = largeImageEnv.name;
+    const LARGE_IMAGE_NAME = Cypress._.toLower(largeImageEnv.name);
     const LARGE_IMAGE_URL = largeImageEnv.url;
 
     it('Create an image with valid image URL', () => {
@@ -85,7 +85,7 @@ describe('Create an image with valid image URL', () => {
 
         cy.wrap(image.save()).then((realName) => {
             // check IMAGE state
-            image.checkState({ name: IMAGE_NAME });
+            image.checkState_without_size({ name: IMAGE_NAME });
 
             // edit IMAGE
             image.goToEdit(IMAGE_NAME);
@@ -108,7 +108,7 @@ describe('Create an image with valid image URL', () => {
         image.setBasics({ url: IMAGE_URL });
         cy.wrap(image.save()).then((realName) => {
             // check IMAGE state
-            image.checkState({ name: IMAGE_NAME });
+            image.checkState_without_size({ name: IMAGE_NAME });
 
             // delete IMAGE
             image.delete(namespace, realName as string, IMAGE_NAME);
@@ -129,8 +129,9 @@ describe('Create an image with valid image URL', () => {
             // check IMAGE state
             image.checkState_without_size({ name: LARGE_IMAGE_NAME });
 
+            // post-cleanup: delete the large image after the test
+            image.delete(namespace, realName as string, LARGE_IMAGE_NAME);
         })
-
     });
 
 });
@@ -180,10 +181,11 @@ describe('Delete VM with exported image', () => {
 
         const imageEnv = Cypress.env('image');
         const namespace = 'default';
+        // vms.init() lowercases the image name when creating it, so the dropdown
         const volumes = [{
             buttonText: 'Add Volume',
             create: false,
-            image: `default/${imageEnv.name}`,
+            image: `default/${Cypress._.toLower(imageEnv.name)}`,
         }];
 
         // create VM
@@ -231,7 +233,7 @@ describe('Update image labels after deleting source VM', () => {
         const volumes = [{
             buttonText: 'Add Volume',
             create: false,
-            image: `default/${imageEnv.name}`,
+            image: `default/${Cypress._.toLower(imageEnv.name)}`,
         }];
 
         // create VM
@@ -372,9 +374,6 @@ describe('Create a ISO image via upload', () => {
 });
 
 
-/**
- * https://harvester.github.io/tests/manual/_incoming/2562-clone-image/
- */
 describe('Clone image', () => {
     const IMAGE_NAME = generateName('auto-image-test');
     const CLONED_NAME = generateName('cloned-image');
@@ -400,7 +399,7 @@ describe('Clone image', () => {
             IMAGE_REAL_NAME = realName as string;
         })
 
-        image.checkState({ name: IMAGE_NAME });
+        image.checkState_without_size({ name: IMAGE_NAME });
         image.clickAction(IMAGE_NAME, 'Clone');
         image.setNameNsDescription(CLONED_NAME, namespace);
 
@@ -408,7 +407,7 @@ describe('Clone image', () => {
             CLONED_IMAGE_REAL_NAME = realName as string;
         })
 
-        image.checkState({ name: CLONED_NAME });
+        image.checkState_without_size({ name: CLONED_NAME });
         image.goToEdit(CLONED_NAME);
         image.clickTab('labels');
 
@@ -449,7 +448,7 @@ describe('Image filtering by labels', () => {
         cy.wrap(image.save()).then((realName) => {
             IMAGE_REAL_NAME_1 = realName as string
         })
-        image.checkState({ name: IMAGE_NAME_1 });
+        image.checkState_without_size({ name: IMAGE_NAME_1 });
 
         // create the second one
         image.goToCreate();
@@ -461,7 +460,7 @@ describe('Image filtering by labels', () => {
         cy.wrap(image.save()).then((realName) => {
             IMAGE_REAL_NAME_2 = realName as string
         })
-        image.checkState({ name: IMAGE_NAME_2 });
+        image.checkState_without_size({ name: IMAGE_NAME_2 });
 
         image.goToCreate();
         image.setNameNsDescription(IMAGE_NAME_3, namespace);
@@ -472,7 +471,7 @@ describe('Image filtering by labels', () => {
         cy.wrap(image.save()).then((realName) => {
             IMAGE_REAL_NAME_3 = realName as string
         })
-        image.checkState({ name: IMAGE_NAME_3 });
+        image.checkState_without_size({ name: IMAGE_NAME_3 });
 
         // Can search specific image by name in the Harvester VM creation page
         vms.goToCreate();
@@ -554,18 +553,27 @@ describe('Image naming with inline CSS', () => {
 
         cy.wrap(image.save()).then((realName) => {
             name = realName as string;
-        })
-        // check IMAGE state
-        image.checkState({ name: IMAGE_NAME });
 
-        // edit IMAGE
+            // The display name contains HTML tags which break the search box.
+            // Use the metadata name (realName) to verify state via API instead.
+            cy.intercept('GET', `/v1/harvester/${HCI.IMAGE}s*`).as('imageList');
+            image.goToList();
+            cy.wait('@imageList');
+
+            // Verify state and progress via direct row lookup using the metadata name
+            cy.contains(IMAGE_NAME, { timeout: constants.timeout.downloadTimeout }).closest('tr').within(() => {
+                cy.get('td').eq(1).should('contain', 'Active');
+                cy.get('td').eq(6).should('contain', 'Completed');
+            });
+        })
+
+        // edit IMAGE — verify the title on detail page shows the raw name (not rendered as HTML)
         image.goToDetail({ name: IMAGE_NAME, ns: namespace });
-        // Get the title name on the image details page
-        cy.get('.resource-name').should('contain', IMAGE_NAME)
+        cy.get('.resource-name').should('contain', IMAGE_NAME);
 
         // delete IMAGE
         cy.wrap(null).then(() => {
-            image.delete(namespace, name, IMAGE_NAME)
+            image.delete(namespace, name, IMAGE_NAME);
         })
     });
 });

--- a/testcases/networks/cluster-network.spec.ts
+++ b/testcases/networks/cluster-network.spec.ts
@@ -10,6 +10,12 @@ beforeEach(() => {
     cy.login({url: PageUrl.clusterNetwork});
 });
 
+after(() => {
+    cy.login();
+    clusterNetwork.deleteFromStore('nc', 'network.harvesterhci.io.vlanconfig');
+    clusterNetwork.deleteFromStore('cn');
+});
+
 /**
  * 1. Login
  * 2. Navigate to the Networks -> Cluster Network Configuration page
@@ -36,14 +42,19 @@ describe('Cluster Network Configuration', () => {
    * 4. Click the `Create Network Config` button
    * 5. Input the Name `nc` of the Network Config
    * 6. Click the Uplink tab
-   * 7. Click to select the `ens6 (Up)` from the NICs dropdown list
+   * 7. Select the NIC from vlans[0].nic in cypress.env.json (e.g. "eno50")
    * 8. Click the create button
    * 9. Check the network config named `nc` exists under the `cn` cluster network panel 
    */
   it('Create network configuration', () => {
     onlyOn(clusterNetworkCreated);
 
-    clusterNetwork.createNetworkConfig('nc', 'ens6 (Up)');
+    // Read the NIC name from env vlans[0] instead of hardcoding it.
+    // selectNIC uses partial text match so it works regardless of the
+    // live status suffix the UI appends (e.g. "eno50 (Up)").
+    const nic = Cypress.env('networks')?.nic;
+
+    clusterNetwork.createNetworkConfig('nc', nic);
 
     clusterNetwork.checkNetworkConfig('nc', 'cn');
   });

--- a/testcases/networks/network.spec.ts
+++ b/testcases/networks/network.spec.ts
@@ -1,9 +1,40 @@
 import TablePo from "@/utils/components/table.po";
 import NetworkPage from "@/pageobjects/network.po";
+import clusterNetworkPage from '@/pageobjects/clusterNetwork.po';
 import { generateName } from '@/utils/utils';
+import { onlyOn } from "@cypress/skip-test";
 
 const network = new NetworkPage();
 const table = new TablePo();
+const clusterNetworkPo = new clusterNetworkPage();
+const clusterNetworkName = `cn-${String(Date.now()).slice(-8)}`;
+
+before(() => {
+  const nic = Cypress.env('networks')?.nic;
+  cy.login();
+  clusterNetworkPo.createClusterNetwork(clusterNetworkName);
+  clusterNetworkPo.createNetworkConfig(`${clusterNetworkName}-nc`, nic);
+});
+
+after(() => {
+  const networksEnv = Cypress.env('networks') || {};
+  cy.login();
+
+  // 1. Delete VM networks created by "Preset Vlans" tests
+  const vmNetworkType = 'k8s.cni.cncf.io.networkattachmentdefinition';
+  const vlan0 = networksEnv.vlans?.[0] ?? 2011;
+  network.deleteFromStore(`default/vlan${vlan0}`, vmNetworkType);
+  if ((networksEnv.vlans?.length ?? 0) >= 2) {
+    const vlanId1 = networksEnv.vlans[1];
+    network.deleteFromStore(`default/vlan${vlanId1}`, vmNetworkType);
+  }
+
+  // 2. Delete network config
+  clusterNetworkPo.deleteFromStore(`${clusterNetworkName}-nc`, 'network.harvesterhci.io.vlanconfig');
+
+  // 3. Delete cluster network
+  clusterNetworkPo.deleteFromStore(clusterNetworkName);
+});
 
 interface Vlan {
   name: string,
@@ -25,13 +56,25 @@ describe('Check create/delete network', () => {
     cy.login();
 
     const name = generateName('test-network-create');
+    const networksEnv = Cypress.env('networks') || {};
 
     network.create({
       name,
       namespace: 'default',
-      vlan: '233',
-      clusterNetwork: 'mgmt'
+      vlan: networksEnv.vlans?.[0],
+      clusterNetwork: clusterNetworkName
     })
+
+    table.clickFlatListBtn();
+
+    network.checkVlanState({
+      name,
+      namespace: 'default',
+      state: 'Active',
+      routeConnectivity: 'Active',
+      vlanID: String(networksEnv.vlans?.[0]),
+      clusterNetwork: clusterNetworkName,
+    });
 
     network.delete('default', name)
   });
@@ -46,6 +89,8 @@ describe('Check create/delete network', () => {
  * 1. Create network with DHCP server IP success
 */
 export function CheckDHCP() { }
+// As per https://github.com/harvester/harvester/issues/11016
+// The combination of Auto (DHCP) mode with a manually specified DHCP server IP is not supposed to work.
 describe('Check network with DHCP', () => {
   it('Check network with DHCP', () => {
     cy.login();
@@ -53,29 +98,36 @@ describe('Check network with DHCP', () => {
     cy.intercept('POST', `/v1/harvester/k8s.cni.cncf.io.network-attachment-definitions`).as('create');
 
     const name = generateName('test-network-create');
-    const dhcp = '172.0.0.1'
+    const networksEnv = Cypress.env('networks') || {};
+    // const dhcp = networksEnv.dhcpServerIP ?? '172.0.0.1';
     const namespace = 'default'
 
     network.create({
       name,
       namespace,
-      vlan: '234',
-      clusterNetwork: 'mgmt',
+      vlan: networksEnv.vlans?.[0],
+      clusterNetwork: clusterNetworkName,
       mode: 'Auto (DHCP)',
-      dhcp,
     })
 
     cy.wait('@create').then(res => {
       expect(res.response?.statusCode).to.equal(201);
       const route = res.response?.body?.metadata?.annotations['network.harvesterhci.io/route']
 
-      if (route) {
-        const json = JSON.parse(route)
-        expect(json.serverIPAddr, 'Check Server IP Address').to.equal(dhcp);
-      }
     })
 
-    network.deleteFromStore(`${namespace}/${name}`)
+    table.clickFlatListBtn();
+
+    network.checkVlanState({
+      name,
+      namespace,
+      state: 'Active',
+      routeConnectivity: 'Active',
+      vlanID: String(networksEnv.vlans?.[0]),
+      clusterNetwork: clusterNetworkName,
+    });
+
+    network.deleteFromStore(`${namespace}/${name}`, network.storeType)
   });
 });
 
@@ -96,16 +148,17 @@ describe('Check network with Manual Mode', () => {
     cy.intercept('POST', `/v1/harvester/k8s.cni.cncf.io.network-attachment-definitions`).as('create');
 
     const name = generateName('test-network-create');
-    const cidr = '172.0.0.1/24'
-    const gateway = '172.0.0.1'
+    const networksEnv = Cypress.env('networks') || {};
+    const cidr = networksEnv.cidr ?? '172.0.0.1/24';
+    const gateway = networksEnv.gateway ?? '172.0.0.1';
     const namespace = 'default'
 
     network.create({
       name,
       namespace,
-      vlan: '235',
+      vlan: networksEnv.vlans?.[0],
       mode: 'Manual',
-      clusterNetwork: 'mgmt',
+      clusterNetwork: clusterNetworkName,
       cidr,
       gateway,
     })
@@ -120,12 +173,23 @@ describe('Check network with Manual Mode', () => {
       }
     })
 
-    network.deleteFromStore(`${namespace}/${name}`)
+    table.clickFlatListBtn();
+
+    network.checkVlanState({
+      name,
+      namespace,
+      state: 'Active',
+      routeConnectivity: 'Active',
+      vlanID: String(networksEnv.vlans?.[0]),
+      clusterNetwork: clusterNetworkName,
+    });
+
+    network.deleteFromStore(`${namespace}/${name}`, network.storeType)
   });
 });
 
 
-export function CreateVlan1() { }
+export function CreateVlanPresets() { }
 describe('Preset Vlans', () => {
   function createVlan(vlan: Vlan) {
     cy.intercept('POST', `/v1/harvester/k8s.cni.cncf.io.network-attachment-definitions`).as('create');
@@ -142,19 +206,19 @@ describe('Preset Vlans', () => {
 
     table.clickFlatListBtn();
 
-    cy.wait(2000)
-    cy.wrap('async').then(() => {
-      table.find(name, 2, namespace, 3).then((index) => {
-        if (typeof index === 'number') {
-          cy.get(`[data-testid="sortable-table-${index}-row"]`).find('td').eq(6).should('contain', 'Active')
-        }
-      })
-    })
+    network.checkVlanState({
+      name,
+      namespace,
+      state: 'Active',
+      routeConnectivity: 'Active',
+      vlanID: String(vlan.vlan),
+      clusterNetwork: vlan.clusterNetwork,
+    });
   }
 
   it('Create first Vlan', () => {
-    const vlans = Cypress.env('vlans') || [];
-    const vlan = vlans[0].vlan
+    const networksEnv = Cypress.env('networks') || {};
+    const vlan = networksEnv.vlans?.[0] ?? 2011;
 
     cy.login();
 
@@ -162,13 +226,15 @@ describe('Preset Vlans', () => {
       name: `vlan${vlan}`,
       namespace: 'default',
       vlan,
-      clusterNetwork: 'mgmt',
+      clusterNetwork: clusterNetworkName,
     })
   });
 
   it('Create second Vlan', () => {
-    const vlans = Cypress.env('vlans') || [];
-    const vlan = vlans[1].vlan
+    const networksEnv = Cypress.env('networks') || {};
+    // Skip if fewer than 2 vlans are configured
+    onlyOn((networksEnv.vlans?.length ?? 0) >= 2);
+    const vlan = networksEnv.vlans[1];
 
     cy.login();
 
@@ -176,31 +242,8 @@ describe('Preset Vlans', () => {
       name: `vlan${vlan}`,
       namespace: 'default',
       vlan,
-      clusterNetwork: 'mgmt',
+      clusterNetwork: clusterNetworkName,
     })
   });
 
-  it('Create Vlan with id 1', () => {
-    const vlans = Cypress.env('vlans') || [];
-    const vlan = 1
-
-    cy.login();
-
-    createVlan({
-      name: `vlan${vlan}`,
-      namespace: 'default',
-      vlan,
-      clusterNetwork: 'mgmt',
-    })
-
-    network.checkVlanState({
-      name: `vlan${vlan}`,
-      namespace: 'default',
-      state: 'Active',
-      routeConnectivity: 'Active',
-      vlanID: `${vlan}`,
-      clusterNetwork: 'mgmt',
-    });
-
-  });
 });

--- a/testcases/rancher/rancher_integration.spec.ts
+++ b/testcases/rancher/rancher_integration.spec.ts
@@ -143,20 +143,20 @@ describe('Rancher Integration Test', function () {
     it('Install Harvester UI Extension', { baseUrl: constants.rancherUrl }, () => {
         onlyOn(addUIextensionRepo);
         rancher.rancherLogin();
-        
+
         if (!rancherVersion) {
-            cy.log('Warning: Rancher version not available from previous test');
-            // Either fail the test or fetch it again
+            cy.log('Warning: Rancher version not available from previous test, fetching now');
+            // Fetch rancherVersion and call install inside .then() so it has the correct value
             cy.wrap(rancher.getServerVersion()).then((infoBody) => {
                 const parsedData = JSON.parse(infoBody as string);
                 rancherVersion = parsedData.Version;
                 cy.log(`Fetched Rancher version: ${rancherVersion}`);
+                rancher.install_harvester_ui_extension(constants.harvester_ui_extension_version, rancherVersion);
             });
         } else {
             cy.log(`Using Rancher version: ${rancherVersion}`);
+            rancher.install_harvester_ui_extension(constants.harvester_ui_extension_version, rancherVersion);
         }
-        rancher.install_harvester_ui_extension(constants.harvester_ui_extension_version, rancherVersion);
-
     });
 
     it('Rancher import Harvester', { baseUrl: constants.rancherUrl }, () => {

--- a/testcases/settings/settings.spec.ts
+++ b/testcases/settings/settings.spec.ts
@@ -9,6 +9,24 @@ describe('Setting Page', () => {
         settings.checkIsCurrentPage();
     })
 
+    afterEach(() => {
+        // cy.request() bypasses the UI so the reset works even when the page itself cannot load.
+        cy.request({
+            method: 'GET',
+            url: '/v1/harvester/harvesterhci.io.settings/ui-source',
+            failOnStatusCode: false,
+        }).then(res => {
+            if (res.status === 200) {
+                cy.request({
+                    method: 'PUT',
+                    url: '/v1/harvester/harvesterhci.io.settings/ui-source',
+                    body: { ...res.body, value: 'bundled' },
+                    failOnStatusCode: false,
+                });
+            }
+        });
+    })
+
     /**
      * https://harvester.github.io/tests/manual/advanced/chage-api-ui-source-bundled/
      * 1. Navigate to the Advanced Settings Page via URL
@@ -68,15 +86,43 @@ describe('Setting Page', () => {
  * https://harvester.github.io/tests/manual/advanced/set-s3-backup-target/
  */
 describe('Set backup target S3', () => {
-    beforeEach(() => {
+    beforeEach(function() {
+        // Skip early — before cy.login() — so no unnecessary session setup or blank page
+        const backupTarget = Cypress.env('backupTarget');
+        if (!backupTarget?.endpoint) {
+            this.skip();
+            return;
+        }
         cy.login({ url: PageUrl.setting });
         settings.checkIsCurrentPage(false);
     })
 
-    it('Set backup target S3', () => {
-        settings.clickMenu('backup-target', 'Edit Setting', 'backup-target');
+    afterEach(() => {
+        // Reset backup-target to default via API.
+        // clearBackupTarget() → clickUseDefaultButton() fails here because Harvester only
+        // renders the "Use the default value" button when the saved value differs from the
+        // default.  If update() returned 422 the setting was never persisted, so the button
+        // never appears and cy.click() receives undefined.
+        cy.request({
+            method: 'GET',
+            url: '/v1/harvester/harvesterhci.io.settings/backup-target',
+            failOnStatusCode: false,
+        }).then(res => {
+            if (res.status === 200) {
+                cy.request({
+                    method: 'PUT',
+                    url: '/v1/harvester/harvesterhci.io.settings/backup-target',
+                    body: { ...res.body, value: '' },
+                    failOnStatusCode: false,
+                }).then(r => cy.log(`Reset backup-target: HTTP ${r.status}`));
+            }
+        });
+    })
 
+    it('Set backup target S3', () => {
         const backupTarget = Cypress.env('backupTarget');
+
+        settings.clickMenu('backup-target', 'Edit Setting', 'backup-target');
         settings.setS3BackupTarget({
             type: 'S3',
             endpoint: backupTarget.endpoint,
@@ -84,7 +130,7 @@ describe('Set backup target S3', () => {
             bucketRegion: backupTarget.bucketRegion,
             accessKeyId: backupTarget.accessKey,
             secretAccessKey: backupTarget.secretKey,
-        })
+        });
 
         settings.update('backup-target');
     });

--- a/testcases/virtualmachines/network.spec.ts
+++ b/testcases/virtualmachines/network.spec.ts
@@ -1,129 +1,237 @@
 import NetworkPage from '@/pageobjects/network.po';
+import clusterNetworkPage from '@/pageobjects/clusterNetwork.po';
 import { VmsPage } from "@/pageobjects/virtualmachine.po";
-import { LoginPage } from "@/pageobjects/login.po";
 import { generateName } from '@/utils/utils';
 import { PageUrl } from "@/constants/constants";
 import { Constants } from "@/constants/constants";
+import TablePo from '@/utils/components/table.po';
 
-const network = new NetworkPage()
+const network = new NetworkPage();
+const clusterNetworkPo = new clusterNetworkPage();
 const vms = new VmsPage();
-const login = new LoginPage();
 const constants = new Constants();
+const table = new TablePo();
+
+const networksEnv = Cypress.env('networks') || {};
+const nic: string = networksEnv.nic;
+const vlan: number = networksEnv.vlans?.[0];
+
+// Names used only if this suite needs to create new resources
+const clusterNetworkName = `cn-${String(Date.now()).slice(-8)}`;
+const networkConfigName = `${clusterNetworkName}-nc`;
+const vmNetworkName = `vlan${vlan}`;
+const vmNetworkNamespace = 'default';
+
+// Track what this suite created so after() only deletes what it made
+let createdClusterNetwork = false;
+let createdNetworkConfig = false;
+let createdVmNetwork = false;
+let resolvedClusterNetwork = '';
+
+/**
+ * Setup:
+ * 1. Visit cluster network list - if a CN with a network config group-tab exists, reuse it.
+ * 2. Only create CN + network config if none found.
+ * 3. Visit VM network list - if vmNetworkName exists and is Active (route Active), skip.
+ * 4. Only create VM network if missing.
+ */
+before(() => {
+  cy.login();
+
+  // Ensure the image is uploaded before running VM creation tests
+  vms.init();
+
+  // ── Step 1: Check cluster network list UI ──────────────────────────────────
+  clusterNetworkPo.goToList();
+  cy.get('body').then($body => {
+    // The list groups configs under "Cluster Network: <name>" group tabs
+    const groupTab = $body.find('.group-tab').first();
+    if (groupTab.length > 0) {
+      const match = groupTab.text().match(/Cluster Network:\s*(\S+)/);
+      if (match?.[1]) {
+        resolvedClusterNetwork = match[1].trim();
+        cy.log(`Found existing cluster network on UI: ${resolvedClusterNetwork}`);
+      }
+    }
+  });
+
+  // ── Step 2: Create CN + config only if Step 1 found nothing ───────────────
+  cy.then(() => {
+    if (!resolvedClusterNetwork) {
+      cy.log(`No cluster network found, creating: ${clusterNetworkName}`);
+      clusterNetworkPo.createClusterNetwork(clusterNetworkName);
+      createdClusterNetwork = true;
+      cy.wait(5000); // let controller reconcile NIC availability
+      clusterNetworkPo.createNetworkConfig(networkConfigName, nic);
+      createdNetworkConfig = true;
+      resolvedClusterNetwork = clusterNetworkName;
+    }
+  });
+
+  // ── Step 3: Check VM network list UI ──────────────────────────────────────
+  cy.then(() => {
+    network.goToList();
+    // Switch to flat list so all networks are in a single table
+    table.clickFlatListBtn();
+    cy.get('body').then($body => {
+      let vmNetworkReady = false;
+      $body.find('[data-testid$="-row"]').each((_, row) => {
+        const cells = Cypress.$(row).find('td');
+        // Column 3 = name (0-indexed: 2), Col 2 = state (idx 1), Col 8 = routeConnectivity (idx 7)
+        const name = cells.eq(2).text().trim();
+        const state = cells.eq(1).text().trim();
+        const routeConn = cells.eq(7).text().trim();
+        if (name === vmNetworkName && state.includes('Active') && routeConn.includes('Active')) {
+          vmNetworkReady = true;
+          cy.log(`VM network ${vmNetworkName} is Active with Active route, reusing.`);
+        }
+      });
+      if (!vmNetworkReady) {
+        cy.log(`VM network ${vmNetworkName} not found or not Active, creating on ${resolvedClusterNetwork}...`);
+        network.create({
+          name: vmNetworkName,
+          namespace: vmNetworkNamespace,
+          vlan: String(vlan),
+          clusterNetwork: resolvedClusterNetwork,
+        });
+        createdVmNetwork = true;
+      }
+    });
+  });
+});
+
+after(() => {
+  cy.login();
+
+  // Delete in dependency order: VM network → network config → cluster network
+  // Use cy.request() DELETE — reliable, session cookie from cy.login() is shared
+  if (createdVmNetwork) {
+    cy.request({
+      method: 'DELETE',
+      url: `/v1/harvester/k8s.cni.cncf.io.network-attachment-definitions/${vmNetworkNamespace}/${vmNetworkName}`,
+      failOnStatusCode: false,
+    }).then(res => cy.log(`Deleted VM network ${vmNetworkName}: ${res.status}`));
+  }
+  if (createdNetworkConfig) {
+    cy.request({
+      method: 'DELETE',
+      url: `/v1/harvester/network.harvesterhci.io.vlanconfigs/${networkConfigName}`,
+      failOnStatusCode: false,
+    }).then(res => cy.log(`Deleted network config ${networkConfigName}: ${res.status}`));
+  }
+  if (createdClusterNetwork) {
+    // Wait briefly for network config deletion to propagate before removing CN
+    cy.wait(3000);
+    cy.request({
+      method: 'DELETE',
+      url: `/v1/harvester/network.harvesterhci.io.clusternetworks/${clusterNetworkName}`,
+      failOnStatusCode: false,
+    }).then(res => cy.log(`Deleted cluster network ${clusterNetworkName}: ${res.status}`));
+  }
+});
 
 /**
  * 1. Login
  * 2. Navigate to the VM create page
- * 3. Provide cpu: 1, memory:1
+ * 3. Provide cpu: 1, memory: 1
  * 4. Select opensuse image and use default size
- * 5. Select vlan1 network
+ * 5. Select vlan network from env (networks.vlans[0])
  * 6. Confirm VM is started into running state
  * 7. Check vm can get IP address
  */
-describe('Create VM with vlan1 network', () => {
+describe('Create VM with vlan network', () => {
+  const VM_NAME = generateName('test-vm-vlan');
+
   beforeEach(() => {
     cy.login({ url: PageUrl.virtualMachine });
   });
 
-  it('Create VM with vlan1 network', () => {
-    const VM_NAME = generateName('test-vm-vlan1');
-    const NAMESPACE = 'default';
-    const NETWORK = 'vlan1';
+  afterEach(() => {
+    vms.deleteVMFromStore(`${vmNetworkNamespace}/${VM_NAME}`);
+  });
+
+  it('Create VM with vlan network', () => {
     const largeImageEnv = Cypress.env('largeImage');
 
-    const value = {
+    vms.create({
       name: VM_NAME,
       cpu: '1',
       memory: '1',
-      image: largeImageEnv.name,
-      networks: [{
-        network: NETWORK,
-      }],
-      namespace: NAMESPACE,
-    };
+      image: Cypress._.toLower(largeImageEnv.name),
+      networks: [{ network: vmNetworkName }],
+      namespace: vmNetworkNamespace,
+    });
 
-    // Create the VM
-    vms.create(value);
-
-    // Navigate to VM list to ensure we're on the correct page
     vms.goToList();
 
-    // Confirm VM is started into running state
-    vms.censorInColumn(VM_NAME, 3, NAMESPACE, 4, 'Running', 2, {
+    vms.censorInColumn(VM_NAME, 3, vmNetworkNamespace, 4, 'Running', 2, {
       timeout: constants.timeout.maxTimeout,
-      nameSelector: '.name-console a'
+      nameSelector: '.name-console a',
     });
 
-    // Check VM can get IP address
-    vms.censorInColumn(VM_NAME, 3, NAMESPACE, 4, '.', 7, {
+    vms.censorInColumn(VM_NAME, 3, vmNetworkNamespace, 4, '.', 7, {
       timeout: constants.timeout.maxTimeout,
-      nameSelector: '.name-console a'
+      nameSelector: '.name-console a',
     });
-
-    // Cleanup
-    vms.delete(NAMESPACE, VM_NAME);
   });
-})
+});
 
+/**
+ * 1. Create VM with management network
+ * 2. Confirm VM running
+ * 3. Edit VM to add vlan network from env
+ * 4. Confirm VM running after restart
+ * 5. Check VM has IP address
+ */
 describe('Add a vlan network to existing VM', () => {
   const VM_NAME = generateName('test-network');
-  const NETWORK_1 = 'management Network'
-  const NETWORK_2 = 'vlan1'
-  const NAMESPACE = 'default'
 
   beforeEach(() => {
     cy.login();
   });
 
+  afterEach(() => {
+    vms.deleteVMFromStore(`${vmNetworkNamespace}/${VM_NAME}`);
+  });
+
   it('Add a vlan network to existing VM', () => {
     const largeImageEnv = Cypress.env('largeImage');
 
-    const value = {
+    vms.create({
       name: VM_NAME,
       cpu: '1',
       memory: '1',
-      image: largeImageEnv.name,
-      networks: [{
-        network: NETWORK_1,
-      }],
-      namespace: NAMESPACE,
-    }
+      image: Cypress._.toLower(largeImageEnv.name),
+      networks: [{ network: 'management Network' }],
+      namespace: vmNetworkNamespace,
+    });
 
-    // Create the VM
-    vms.create(value);
-
-    // Navigate to VM list to ensure we're on the correct page
     vms.goToList();
 
-    // Check VM is running initially
-    vms.censorInColumn(VM_NAME, 3, NAMESPACE, 4, 'Running', 2, {
+    vms.censorInColumn(VM_NAME, 3, vmNetworkNamespace, 4, 'Running', 2, {
       timeout: constants.timeout.maxTimeout,
-      nameSelector: '.name-console a'
+      nameSelector: '.name-console a',
     });
 
-    // Edit VM to add second network
-    const editValue = {
-      networks: [{
-        network: NETWORK_1,
-      }, {
-        network: NETWORK_2,
-      }]
-    };
-
-    vms.edit(VM_NAME, editValue);
-
-    // Check VM is in running state after restart
-    vms.censorInColumn(VM_NAME, 3, NAMESPACE, 4, 'Running', 2, {
-      timeout: constants.timeout.maxTimeout,
-      nameSelector: '.name-console a'
+    vms.edit(VM_NAME, {
+      networks: [
+        { network: 'management Network' },
+        { network: vmNetworkName },
+      ],
     });
 
-    // Check VM can get IP address
-    vms.censorInColumn(VM_NAME, 3, NAMESPACE, 4, '.', 7, {
+    // Wait for VM to begin restarting after network interface change
+    cy.wait(15000);
+    vms.goToList();
+
+    vms.censorInColumn(VM_NAME, 3, vmNetworkNamespace, 4, 'Running', 2, {
       timeout: constants.timeout.maxTimeout,
-      nameSelector: '.name-console a'
+      nameSelector: '.name-console a',
     });
 
-    // Cleanup
-    vms.delete(NAMESPACE, VM_NAME);
-  })
-})
+    vms.censorInColumn(VM_NAME, 3, vmNetworkNamespace, 4, '.', 7, {
+      timeout: constants.timeout.maxTimeout,
+      nameSelector: '.name-console a',
+    });
+  });
+});

--- a/testcases/virtualmachines/node-scheduling.spec.ts
+++ b/testcases/virtualmachines/node-scheduling.spec.ts
@@ -1,19 +1,34 @@
 import { VmsPage } from "@/pageobjects/virtualmachine.po";
 
-import { generateName, host as hostUtil } from '@/utils/utils';
+import { generateName } from '@/utils/utils';
 import { Constants } from "@/constants/constants";
 
 const vmPO = new VmsPage();
 const constants = new Constants();
 
+let hostNodes: Array<{ name: string }> = [];
+
+before(() => {
+  cy.login();
+  cy.request({
+    method: 'GET',
+    url: '/v1/harvester/nodes',
+    headers: { Accept: 'application/json' },
+  }).then((resp: Cypress.Response<any>) => {
+    const nodeList: any[] = resp.body?.data ?? resp.body?.items ?? [];
+    hostNodes = nodeList.map((node: any) => ({ name: node.id ?? node.metadata?.name }));
+  });
+});
+
 describe('Stop VM Negative', () => {
-  it('Stop VM Negative', () => {
+  it('Stop VM Negative', function() {
+    if (hostNodes.length < 2) return this.skip();
+
     cy.login();
 
     const VM_NAME = generateName('test-vm-scheduling');
     const namespace = 'default'
-    const firstNode = hostUtil.list()[0];
-    const nodeName = firstNode?.name || firstNode?.customName
+    const nodeName = hostNodes[0].name;
     const imageEnv = Cypress.env('image');
 
     const volume = [{

--- a/testcases/virtualmachines/scheduling.spec.ts
+++ b/testcases/virtualmachines/scheduling.spec.ts
@@ -1,10 +1,22 @@
 import { VmsPage } from "@/pageobjects/virtualmachine.po";
 import { HostsPage } from "@/pageobjects/hosts.po";
-import { host as hostsUtil } from '@/utils/utils';
-import { Node } from '@/models/host'
 
 const vms = new VmsPage();
 const hosts = new HostsPage();
+
+let hostNames: string[] = [];
+
+before(() => {
+  cy.login();
+  cy.request({
+    method: 'GET',
+    url: '/v1/harvester/nodes',
+    headers: { Accept: 'application/json' },
+  }).then((resp: Cypress.Response<any>) => {
+    const nodeList: any[] = resp.body?.data ?? resp.body?.items ?? [];
+    hostNames = nodeList.map((node: any) => node.id ?? node.metadata?.name);
+  });
+});
 
 /**
  * https://harvester.github.io/tests/manual/virtual-machines/vm_schedule_on_node/
@@ -14,10 +26,8 @@ describe('VM scheduling on Specific node', () => {
     cy.login();
   });
 
-  it('Schedule VM on the Node which is Enable Maintenance Mode', () => {
-    const hostList = hostsUtil.list();
-
-    const hostNames: string[] = hostList.map((node: Node) => node.name || node.customName);
+  it('Schedule VM on the Node which is Enable Maintenance Mode', function() {
+    if (hostNames.length < 2) return this.skip();
 
     const maintenanceNodeName = hostNames[0]
     const filterMaintenanceNodeNames = hostNames.filter(name => name !== maintenanceNodeName);

--- a/testcases/virtualmachines/vm-migration.spec.ts
+++ b/testcases/virtualmachines/vm-migration.spec.ts
@@ -7,6 +7,7 @@ import VMBackup from '@/pageobjects/vmBackup.po';
 import { generateName } from '@/utils/utils';
 import { Constants } from "@/constants/constants";
 import { host as hostUtil } from '@/utils/utils';
+import { onlyOn } from "@cypress/skip-test";
 
 const vms = new VmsPage();
 const volumePO = new VolumePage();
@@ -14,6 +15,30 @@ const constants = new Constants();
 const namespaces = new NamespacePage();
 const imagePO = new ImagePage();
 const vmBackups = new VMBackup();
+
+const vmNetworkName = `vlan${(Cypress.env('networks') || {})?.vlans?.[0]}`;
+
+let clusterNodeCount = 0;
+
+before(function() {
+  cy.login();
+  cy.request({
+    method: 'GET',
+    url: '/v1/harvester/nodes',
+    headers: { Accept: 'application/json' },
+  }).then((resp) => {
+    const nodeList: any[] = resp.body?.data ?? resp.body?.items ?? [];
+    clusterNodeCount = nodeList.length;
+    if (clusterNodeCount >= 2) {
+      // Ensure the largeImage is available before migration tests run
+      vms.init();
+    }
+  });
+});
+
+beforeEach(function() {
+  if (clusterNodeCount < 2) this.skip();
+});
 
 /**
  * @module testcases/virtualmachines/vm-migration.spec.ts
@@ -41,7 +66,6 @@ describe('VM Live Migration', () => {
   it('Migrate VM with cloud init data', () => {
     const VM_NAME = generateName('test-vm-migrate');
     const NAMESPACE = 'default'
-    const NETWORK = 'vlan1'
     const largeImageEnv = Cypress.env('largeImage');
     const USERDATA = `#cloud-config
 password: password
@@ -53,9 +77,9 @@ sshpwauth: True
       name: VM_NAME,
       cpu: '1',
       memory: '2',
-      image: largeImageEnv.name,
+      image: Cypress._.toLower(largeImageEnv.name),
       networks: [{
-        network: NETWORK,
+        network: vmNetworkName,
       }],
       guestAgent: true,
       namespace: NAMESPACE,
@@ -173,7 +197,6 @@ sshpwauth: True
   it('Migrate VM with one backup', () => {
     const VM_NAME = generateName('test-vm-migrate-backup');
     const NAMESPACE = 'default'
-    const NETWORK = 'vlan1'
     const largeImageEnv = Cypress.env('largeImage');
     const BACKUP_NAME = `backup-${VM_NAME}`;
     const USERDATA = `#cloud-config
@@ -186,9 +209,9 @@ sshpwauth: True
       name: VM_NAME,
       cpu: '1',
       memory: '2',
-      image: largeImageEnv.name,
+      image: Cypress._.toLower(largeImageEnv.name),
       networks: [{
-        network: NETWORK,
+        network: vmNetworkName,
       }],
       guestAgent: true,
       namespace: NAMESPACE,
@@ -323,7 +346,6 @@ sshpwauth: True
   it('Migrate VM has multiple volumes', () => {
     const VM_NAME = generateName('test-vm-migrate-volumes');
     const NAMESPACE = 'default'
-    const NETWORK = 'vlan1'
     const VOLUME_NAME = generateName('migration-vol');
     const largeImageEnv = Cypress.env('largeImage');
     const USERDATA = `#cloud-config
@@ -344,9 +366,9 @@ sshpwauth: True
       name: VM_NAME,
       cpu: '1',
       memory: '2',
-      image: largeImageEnv.name,
+      image: Cypress._.toLower(largeImageEnv.name),
       networks: [{
-        network: NETWORK,
+        network: vmNetworkName,
       }],
       guestAgent: true,
       namespace: NAMESPACE,

--- a/testcases/volume/volumes.spec.ts
+++ b/testcases/volume/volumes.spec.ts
@@ -33,7 +33,7 @@ describe("Create image from Volume", () => {
     const volumes = [{
       buttonText: 'Add Volume',
       create: false,
-      image: `default/${imageEnv.name}`,
+      image: `default/${Cypress._.toLower(imageEnv.name)}`,
     }];
 
     vms.init();
@@ -104,7 +104,7 @@ describe("Create volume root disk VM Image Form", () => {
     // create VOLUME
     volumes.goToCreate();
     volumes.setNameNsDescription(VOLUME_NAME, namespace);
-    volumes.setBasics({ source: 'Virtual Machine Image', image: imageEnv.name, size: '10' });
+    volumes.setBasics({ source: 'Virtual Machine Image', image: Cypress._.toLower(imageEnv.name), size: '10' });
     volumes.save();
 
     // check state
@@ -138,7 +138,7 @@ describe("Delete volume that was attached to VM but now is not", () => {
     const volumesInVM = [{
       buttonText: 'Add Volume',
       create: false,
-      image: `default/${imageEnv.name}`,
+      image: `default/${Cypress._.toLower(imageEnv.name)}`,
     }];
 
     // create VM
@@ -195,7 +195,7 @@ describe("Support Volume Hot Unplug", () => {
     const volumesInVM = [{
       buttonText: 'Add Volume',
       create: false,
-      image: `default/${imageEnv.name}`,
+      image: `default/${Cypress._.toLower(imageEnv.name)}`,
     }];
 
     // create VOLUME
@@ -256,7 +256,7 @@ describe("Edit volume increase size via form", () => {
     const volumesInVM = [{
       buttonText: 'Add Volume',
       create: false,
-      image: `default/${imageEnv.name}`,
+      image: `default/${Cypress._.toLower(imageEnv.name)}`,
       size: '10'
     }];
 

--- a/utils/components/cru-resource.po.ts
+++ b/utils/components/cru-resource.po.ts
@@ -29,8 +29,8 @@ export default class CruResourcePo extends PagePo {
   public footerButtons = '.cru-resource-footer'
   public confirmRemove = '.card-container.prompt-remove'
   public searchInput = '.search'
-  // Some action menus still use old style (.list-unstyled.menu), while other menus are in new style (.dropdownTarget)
-  public actionMenu = '.dropdownTarget[role="menu"], .list-unstyled.menu'
+  // Some action menus still use old style (.list-unstyled.menu), new style (.dropdownTarget), or v-popper (.v-popper__inner)
+  public actionMenu = '.dropdownTarget[role="menu"], .list-unstyled.menu, .v-popper__inner'
   public actionMenuIcon = '.icon-actions'
   public actionButton = '[data-testid="masthead-create"]';
 
@@ -212,10 +212,10 @@ export default class CruResourcePo extends PagePo {
 
     // VM stop/pause actions has to click apply in one more confirmation modal
     if(action?.toLowerCase() === 'stop' || action?.toLowerCase() === 'pause') {
-      cy.get(this.actionMenu).contains(action).click()
+      cy.get(this.actionMenu).contains(action).should('be.visible').click()
       return cy.get('#modals button[data-testid="action-button-async-button"]').click()
     }else{
-      return cy.get(this.actionMenu).contains(action).click()
+      return cy.get(this.actionMenu).contains(action).should('be.visible').click()
     }
    
   }


### PR DESCRIPTION
Test Suite Improvements
1. **Cypress.env.json**
       Removed unused host array (host name/count is computed), added networks object with NIC, CIDR, gateway, and VLAN       IDs for VM network tests.
2. **Unique name for resources**
3. **Rancher UI Extension installation**
      Added idempotency: skip if correct version already installed, trigger Update if version mismatches. Fixed async bug where rancherVersion was read before its fetch resolved. Added Rancher v2.13+ UI flow detection and extended reload-banner timeout to uploadTimeout.
4. **Added Resource cleanup after tests**
5. **Redundant login prevention**
    cy.login() consolidated into beforeEach() with { url: PageUrl.xxx } so each test starts at the correct page in a single call instead of logging in again inside each it() block.
6. **Image readiness check without size**
      Test was hardcoded with check of 16Mi image size which should not be the case, image is configurable at Jenkins level.
7. **Network test**
    - before() reuses an existing NAD otherwise creates a fresh one.
    - Uses vlanid, cidr etc from env.json
    - Updated test as per https://github.com/harvester/harvester/issues/11016
    - Check the route connectivity also to assert the NAD is active