### PR TITLE
updated inline CSS test to expect a 422 error. Updated the invalid UR…

### DIFF
--- a/pageobjects/image.po.ts
+++ b/pageobjects/image.po.ts
@@ -112,7 +112,7 @@ export class ImagePage extends CruResourcePo {
     })
   }
 
-  public save({ upload, edit, depth }: { namespace?: string, buttonText?: string, upload?: boolean; edit?: boolean; depth?: number; } = {}): Promise<string> {
+  public save({ upload, edit, depth }: { namespace?: string, response?: string, buttonText?: string, upload?: boolean; edit?: boolean; depth?: number; } = {}): Promise<string> {
     return new Promise((resolve, reject) => {
       const interceptName = generateName('create');
 
@@ -121,7 +121,12 @@ export class ImagePage extends CruResourcePo {
       cy.wait(`@${interceptName}`).then(async (res) => {
         if (edit && res.response?.statusCode === 409 && depth === 0) {
           await this.save({ upload, edit, depth: depth + 1 })
-        } else {
+        } 
+        else if(res.response?.statusCode === 422) {
+          cy.log(String(res.response?.statusCode))
+          resolve(String(res.response?.statusCode))
+          }
+        else {
           expect(res.response?.statusCode, `Check save success`).to.equal(edit ? 200 : 201);
           resolve(res.response?.body?.metadata?.name || '');
         }

--- a/testcases/image/images.spec.ts
+++ b/testcases/image/images.spec.ts
@@ -152,7 +152,7 @@ describe('Create image with invalid URL', () => {
 
         image.goToCreate();
         image.setNameNsDescription(IMAGE_NAME, namespace);
-        image.setBasics({ url: 'http://download.invalid.net/test.img' });
+        image.setBasics({ url: 'http://download.invalid/test.img' });
 
         cy.wrap(image.save()).then((realName) => {
             image.censorInColumn(IMAGE_NAME, 3, namespace, 4, 'Failed', 2, { timeout: constants.timeout.uploadTimeout });
@@ -551,29 +551,8 @@ describe('Image naming with inline CSS', () => {
         image.setNameNsDescription(IMAGE_NAME, namespace);
         image.setBasics({ url: IMAGE_URL });
 
-        cy.wrap(image.save()).then((realName) => {
-            name = realName as string;
-
-            // The display name contains HTML tags which break the search box.
-            // Use the metadata name (realName) to verify state via API instead.
-            cy.intercept('GET', `/v1/harvester/${HCI.IMAGE}s*`).as('imageList');
-            image.goToList();
-            cy.wait('@imageList');
-
-            // Verify state and progress via direct row lookup using the metadata name
-            cy.contains(IMAGE_NAME, { timeout: constants.timeout.downloadTimeout }).closest('tr').within(() => {
-                cy.get('td').eq(1).should('contain', 'Active');
-                cy.get('td').eq(6).should('contain', 'Completed');
-            });
-        })
-
-        // edit IMAGE — verify the title on detail page shows the raw name (not rendered as HTML)
-        image.goToDetail({ name: IMAGE_NAME, ns: namespace });
-        cy.get('.resource-name').should('contain', IMAGE_NAME);
-
-        // delete IMAGE
-        cy.wrap(null).then(() => {
-            image.delete(namespace, name, IMAGE_NAME);
+        cy.wrap(image.save()).then((res) => {
+            expect(res).to.contain('422')
         })
     });
 });


### PR DESCRIPTION
    updated inline CSS test to expect a 422 error. Updated the invalid URL test to use a URL that is always invalid. I was seeing it still download HTML from the location when it accessed invalid.net

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
* Issue : [2798](https://github.com/harvester/tests/issues/2798)

#### What this PR does / why we need it:
This changes the behavior of the inline CSS test. We started enforcing [RFC 1123](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names) in the name field on image creation. In the past we didn't do that and the test was to validate that it wouldn't render inline CSS/HTML on the page. Now it's going to validate that we are blocking invalid names. It's still valuable, but the thing it's testing has changed. I also changed the invalid URL for the invalid URL test. That is an actual URL that we don't own so I changed it to a .local URL that won't route to the internet.

#### Test Result - fixed the following test cases:
<img width="877" height="808" alt="Screenshot_20260730_112530" src="https://github.com/user-attachments/assets/051e7155-7e1f-41b5-b0ef-b82b0801e4cf" />

