### PR TITLE
Fix backup tests on CI Jenkins for Harvester v1.9

### DIFF
--- a/testcases/backupAndSnapshot/vmBackup.spec.ts
+++ b/testcases/backupAndSnapshot/vmBackup.spec.ts
@@ -29,24 +29,24 @@ describe('VM Backup Validation', () => {
       try { parsed = JSON.parse(res.body?.value); } catch (e) {}
 
       if (!parsed?.endpoint) {
-        cy.log('Backup target not configured — setting NFS backup target');
+        cy.log('Backup target not configured — setting S3 backup target');
+        const backupTarget = Cypress.env('backupTarget');
+
         settings.clickMenu('backup-target', 'Edit Setting', 'backup-target');
-        settings.setNFSBackupTarget('NFS', Cypress.env('nfsEndPoint'));
+        settings.setS3BackupTarget({
+          type: 'S3',
+          endpoint: backupTarget.endpoint,
+          bucketName: backupTarget.bucketName,
+          bucketRegion: backupTarget.bucketRegion,
+          accessKeyId: backupTarget.accessKey,
+          secretAccessKey: backupTarget.secretKey,
+        });
         settings.update('backup-target');
         backupTargetSetByTest = true;
       } else {
         cy.log(`Backup target already configured: ${parsed.type || 'unknown type'}`);
       }
     });
-  });
-
-  after(() => {
-    // Only clear the backup target if this test suite was the one that set it
-    if (backupTargetSetByTest) {
-      cy.log('Clearing backup target set by this test suite');
-      cy.login({ url: PageUrl.setting });
-      settings.clearBackupTarget();
-    }
   });
 
   beforeEach(() => {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
* Issue : https://github.com/harvester/tests/issues/2799

#### What this PR does / why we need it:

Based on the recent test result on v1.9.0-rc3 of the backup related tests


- backupAndSnapshot
	- ❌ vmBackup.spec.ts -> 1 Failed and 4 Blocked
	
        <img width="1600" height="728" alt="image" src="https://github.com/user-attachments/assets/929bc9b4-4aae-4051-b06a-9b1c365a0ab8" />

#### Root cause

- ❌ Take a vm backup from vm
  - Test failed at `AFTER ALL` , test trying to set backup target to NFS with S3 backup endpoint
  
      <img width="1600" height="729" alt="image" src="https://github.com/user-attachments/assets/e2de816e-13a9-47b3-adf6-3bff5467db38" />

#### Solution
1. Update the before() action to configure on S3 backup target
2. Remove the after() action to clean up backup target since this settings is required for the follow up tests like vm live migration. 

#### Test Result - fixed the following test cases:

After the fix, trigger the test locally to the remote bare-metal environment


#### vmBackup.spec test result


* With S3 backup previously configured 

  <img width="1589" height="723" alt="Image" src="https://github.com/user-attachments/assets/361913ec-fbef-4b32-b04c-ccd8b95852f6" />


* Without S3 backup previously configured 

  <img width="1593" height="723" alt="Image" src="https://github.com/user-attachments/assets/c0e2eae9-6419-4a12-8de3-920f43da1b37" />


#### vmSnapshot.spec test result

  <img width="1598" height="729" alt="Image" src="https://github.com/user-attachments/assets/db9de583-53f1-41ec-a5bf-64c4c9a2cc1b" />